### PR TITLE
fix(grandexchange): Tab Changing and Search Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,78 +1,57 @@
-# [1.1.0](https://github.com/Torwent/SRL-T/compare/v1.0.11...v1.1.0) (2023-03-19)
+# [1.1.0](https://github.com/Garrett3Nelson/SRL/compare/v1.0.8...v1.1.0) (2023-03-20)
 
 
 ### Bug Fixes
 
-* regenerate changelog and add deprecated warnign to TRSBank.FindItem(): Boolean ([4feabaf](https://github.com/Torwent/SRL-T/commit/4feabafe07f7585a6d944befa9d7d599e23b275d))
+* **grandexchange:** Added HISTORY overview screen ([b21f8f6](https://github.com/Garrett3Nelson/SRL/commit/b21f8f66eba7a81c8cdbf459139ea9830d55accb))
+* **grandexchange:** Corrected font for value reading ([9849c19](https://github.com/Garrett3Nelson/SRL/commit/9849c198441a68c0d54a0d2baf379ec56ecca408))
+* **grandexchange:** Fixed search to work with multiline results ([e604c41](https://github.com/Garrett3Nelson/SRL/commit/e604c41febef8283dd7888f5d0f044535cfa925b))
+* regenerate changelog and add deprecated warnign to TRSBank.FindItem(): Boolean ([4feabaf](https://github.com/Garrett3Nelson/SRL/commit/4feabafe07f7585a6d944befa9d7d599e23b275d))
 
 
 
-## [1.0.11](https://github.com/Torwent/SRL-T/compare/v1.0.10...v1.0.11) (2023-03-17)
-
-
-### Bug Fixes
-
-* attempt to fix SRL-T docs. You can ignore this, nothing changed ([4ec939b](https://github.com/Torwent/SRL-T/commit/4ec939b327dd4d20028bb2d7f78b582e8a4111c7))
-
-
-
-## [1.0.10](https://github.com/Torwent/SRL-T/compare/v1.0.9...v1.0.10) (2023-03-16)
+## [1.0.8](https://github.com/Garrett3Nelson/SRL/compare/f65bc17a9d9cfb93a5b76ffa3ff072c44e92c3cf...v1.0.8) (2023-03-18)
 
 
 ### Bug Fixes
 
-* **TRSBank:** The bank interface in SRL-T now checks for and handles the item incinerator ([288bff7](https://github.com/Torwent/SRL-T/commit/288bff7579234d3f0c5c7614b6fe1a5c9fb61193))
+* added missing login message ([53b59b9](https://github.com/Garrett3Nelson/SRL/commit/53b59b904fa4948dc54b5dd5b398fcc4eb187769))
+* attempt to fix SRL-T docs. You can ignore this, nothing changed ([4ec939b](https://github.com/Garrett3Nelson/SRL/commit/4ec939b327dd4d20028bb2d7f78b582e8a4111c7))
+* attempt to fix version not detected ([3d3e7d3](https://github.com/Garrett3Nelson/SRL/commit/3d3e7d3c87b623699b986d4af012a02563f32ae6))
+* ensured scrollbar is scrollable! ([2f1b192](https://github.com/Garrett3Nelson/SRL/commit/2f1b192425d4ed9357d7a9ddee8da509d77ecd35))
+* fixed an issue with T2DPointArray.Smallest() and T2DPointArray.Biggest() ([26ebd30](https://github.com/Garrett3Nelson/SRL/commit/26ebd30251848495703fe9786176cb4fbaf57499))
+* fixed issues with GameTabs.GetCurrentTab ([cd9d6f6](https://github.com/Garrett3Nelson/SRL/commit/cd9d6f63ffa02a6a7d3914e62073ed461eb89e8a))
+* force bump version ([0a1c553](https://github.com/Garrett3Nelson/SRL/commit/0a1c55323cc259d19ef569c426caad012fb36f82))
+* GlobalToRegion was not properly offset. ([2c4980e](https://github.com/Garrett3Nelson/SRL/commit/2c4980eaa67a3f5f0d664b7cdde3dd6b74f6403f))
+* Inventory.FindItems was not returning the actual slots the items were in. ([1cb1396](https://github.com/Garrett3Nelson/SRL/commit/1cb1396ca366c4243e56fd9c7561114dc7506d0b))
+* itemfinder ([36c75ef](https://github.com/Garrett3Nelson/SRL/commit/36c75effb2c3125f19c260c19669f8b299c4a0c0))
+* **itemfinder:** fixed noted items ([094b89f](https://github.com/Garrett3Nelson/SRL/commit/094b89f3cf0356a652ffe0158f338dbb08adbdb0))
+* magic tab detection ([ea19aae](https://github.com/Garrett3Nelson/SRL/commit/ea19aae596e75c4cbf8274ed44a1612538243437))
+* my SRL was renamed to SRL-T ([f2cbbb8](https://github.com/Garrett3Nelson/SRL/commit/f2cbbb80b2a6826af695b07f241d52b858a5c213))
+* remove left over debugging ([39cdf67](https://github.com/Garrett3Nelson/SRL/commit/39cdf67af91365a1035937e5d19266d3d6fd29da))
+* stop crashes from checking tabs when they are not available ([4724a18](https://github.com/Garrett3Nelson/SRL/commit/4724a188446c9f66123af7b15b6c928fceef28ce))
+* TAntiban.AdjustZoom() ([3e2cb2d](https://github.com/Garrett3Nelson/SRL/commit/3e2cb2dc057661b177c6ca74e581be7e3f4484f1))
+* **TPoint:** added new methods from 1500 ([b645324](https://github.com/Garrett3Nelson/SRL/commit/b645324c2f4f74c8a02725ddbd1e3b9de966f9b0))
+* **TRSBank:** The bank interface in SRL-T now checks for and handles the item incinerator ([288bff7](https://github.com/Garrett3Nelson/SRL/commit/288bff7579234d3f0c5c7614b6fe1a5c9fb61193))
+* TRSLogin tweaks and documentation ([5e98218](https://github.com/Garrett3Nelson/SRL/commit/5e98218799aeebbc39e3a3eec38b7cc5830829c9))
+* TRSMake fixes ([#68](https://github.com/Garrett3Nelson/SRL/issues/68)) ([f4b1a62](https://github.com/Garrett3Nelson/SRL/commit/f4b1a6269a0f0091de5621119d7d2437e41734be))
+* typo in Antiban.OnSleeping ([7c71920](https://github.com/Garrett3Nelson/SRL/commit/7c71920d3bd81fb3d0e97d8db1188bf2ca4003d5))
+* update docs link ([e85e2fd](https://github.com/Garrett3Nelson/SRL/commit/e85e2fdf90b960272621715c83a176b846fb9a35))
+* update item-finder ([4130cf5](https://github.com/Garrett3Nelson/SRL/commit/4130cf587705549e10fa0cb8bc604f46375a30dc))
+* update remoteinput plugin ([ec1f4e9](https://github.com/Garrett3Nelson/SRL/commit/ec1f4e93b32a664cb38b47e5cac266c22dd74a36))
+* update version gh action ([3ee9b0b](https://github.com/Garrett3Nelson/SRL/commit/3ee9b0b18a1058339966c04ce7788692cedc7b81))
 
 
-
-## [1.0.9](https://github.com/Torwent/SRL-T/compare/v1.0.8...v1.0.9) (2023-02-15)
-
-
-### Bug Fixes
-
-* **TPoint:** added new methods from 1500 ([b645324](https://github.com/Torwent/SRL-T/commit/b645324c2f4f74c8a02725ddbd1e3b9de966f9b0))
-
-
-
-## [1.0.8](https://github.com/Torwent/SRL-T/compare/f65bc17a9d9cfb93a5b76ffa3ff072c44e92c3cf...v1.0.8) (2023-02-11)
-
-
-### Bug Fixes
-
-* added missing login message ([53b59b9](https://github.com/Torwent/SRL-T/commit/53b59b904fa4948dc54b5dd5b398fcc4eb187769))
-* attempt to fix version not detected ([3d3e7d3](https://github.com/Torwent/SRL-T/commit/3d3e7d3c87b623699b986d4af012a02563f32ae6))
-* ensured scrollbar is scrollable! ([2f1b192](https://github.com/Torwent/SRL-T/commit/2f1b192425d4ed9357d7a9ddee8da509d77ecd35))
-* fixed an issue with T2DPointArray.Smallest() and T2DPointArray.Biggest() ([26ebd30](https://github.com/Torwent/SRL-T/commit/26ebd30251848495703fe9786176cb4fbaf57499))
-* fixed issues with GameTabs.GetCurrentTab ([cd9d6f6](https://github.com/Torwent/SRL-T/commit/cd9d6f63ffa02a6a7d3914e62073ed461eb89e8a))
-* force bump version ([0a1c553](https://github.com/Torwent/SRL-T/commit/0a1c55323cc259d19ef569c426caad012fb36f82))
-* GlobalToRegion was not properly offset. ([2c4980e](https://github.com/Torwent/SRL-T/commit/2c4980eaa67a3f5f0d664b7cdde3dd6b74f6403f))
-* Inventory.FindItems was not returning the actual slots the items were in. ([1cb1396](https://github.com/Torwent/SRL-T/commit/1cb1396ca366c4243e56fd9c7561114dc7506d0b))
-* itemfinder ([36c75ef](https://github.com/Torwent/SRL-T/commit/36c75effb2c3125f19c260c19669f8b299c4a0c0))
-* **itemfinder:** fixed noted items ([094b89f](https://github.com/Torwent/SRL-T/commit/094b89f3cf0356a652ffe0158f338dbb08adbdb0))
-* magic tab detection ([ea19aae](https://github.com/Torwent/SRL-T/commit/ea19aae596e75c4cbf8274ed44a1612538243437))
-* my SRL was renamed to SRL-T ([f2cbbb8](https://github.com/Torwent/SRL-T/commit/f2cbbb80b2a6826af695b07f241d52b858a5c213))
-* remove left over debugging ([39cdf67](https://github.com/Torwent/SRL-T/commit/39cdf67af91365a1035937e5d19266d3d6fd29da))
-* stop crashes from checking tabs when they are not available ([4724a18](https://github.com/Torwent/SRL-T/commit/4724a188446c9f66123af7b15b6c928fceef28ce))
-* TAntiban.AdjustZoom() ([3e2cb2d](https://github.com/Torwent/SRL-T/commit/3e2cb2dc057661b177c6ca74e581be7e3f4484f1))
-* TRSLogin tweaks and documentation ([5e98218](https://github.com/Torwent/SRL-T/commit/5e98218799aeebbc39e3a3eec38b7cc5830829c9))
-* TRSMake fixes ([#68](https://github.com/Torwent/SRL-T/issues/68)) ([f4b1a62](https://github.com/Torwent/SRL-T/commit/f4b1a6269a0f0091de5621119d7d2437e41734be))
-* typo in Antiban.OnSleeping ([7c71920](https://github.com/Torwent/SRL-T/commit/7c71920d3bd81fb3d0e97d8db1188bf2ca4003d5))
-* update docs link ([e85e2fd](https://github.com/Torwent/SRL-T/commit/e85e2fdf90b960272621715c83a176b846fb9a35))
-* update item-finder ([4130cf5](https://github.com/Torwent/SRL-T/commit/4130cf587705549e10fa0cb8bc604f46375a30dc))
-* update remoteinput plugin ([ec1f4e9](https://github.com/Torwent/SRL-T/commit/ec1f4e93b32a664cb38b47e5cac266c22dd74a36))
-* update version gh action ([3ee9b0b](https://github.com/Torwent/SRL-T/commit/3ee9b0b18a1058339966c04ce7788692cedc7b81))
-
-
-* Bug fixes and minor additions (#65) ([0e9d699](https://github.com/Torwent/SRL-T/commit/0e9d69914cafa0e7089ca9eb2bd95febbb069505)), closes [#65](https://github.com/Torwent/SRL-T/issues/65)
+* Bug fixes and minor additions (#65) ([0e9d699](https://github.com/Garrett3Nelson/SRL/commit/0e9d69914cafa0e7089ca9eb2bd95febbb069505)), closes [#65](https://github.com/Garrett3Nelson/SRL/issues/65)
 
 
 ### Features
 
-* added version bumper to my SRL ([d7579eb](https://github.com/Torwent/SRL-T/commit/d7579eb3bc4b2430ae79e2a1ada687b05ad86cea))
-* **bank:** methods to find bank tabs a item is in ([19a335b](https://github.com/Torwent/SRL-T/commit/19a335b85a7d4327f542167fff5724fd4ce56b2c))
-* fixed zoom slider and added brightness slider ([f65bc17](https://github.com/Torwent/SRL-T/commit/f65bc17a9d9cfb93a5b76ffa3ff072c44e92c3cf))
-* new keybindings.simba file to handle FKeys. ([8fd288d](https://github.com/Torwent/SRL-T/commit/8fd288d85da40aa2b9725ca92b033806305c653f))
-* simba1500 walker backport ([54aa5e9](https://github.com/Torwent/SRL-T/commit/54aa5e986585997fd724efd629cb25df94ed492b))
+* added version bumper to my SRL ([d7579eb](https://github.com/Garrett3Nelson/SRL/commit/d7579eb3bc4b2430ae79e2a1ada687b05ad86cea))
+* **bank:** methods to find bank tabs a item is in ([19a335b](https://github.com/Garrett3Nelson/SRL/commit/19a335b85a7d4327f542167fff5724fd4ce56b2c))
+* fixed zoom slider and added brightness slider ([f65bc17](https://github.com/Garrett3Nelson/SRL/commit/f65bc17a9d9cfb93a5b76ffa3ff072c44e92c3cf))
+* new keybindings.simba file to handle FKeys. ([8fd288d](https://github.com/Garrett3Nelson/SRL/commit/8fd288d85da40aa2b9725ca92b033806305c653f))
+* simba1500 walker backport ([54aa5e9](https://github.com/Garrett3Nelson/SRL/commit/54aa5e986585997fd724efd629cb25df94ed492b))
 
 
 ### BREAKING CHANGES

--- a/osr/grandexchange.simba
+++ b/osr/grandexchange.simba
@@ -259,7 +259,7 @@ begin
   end;
   
   if Button.Visible() then
-    Result := OCR.RecognizeNumber(Button.Bounds,  TOCRColorRule.Create([$FFFFFF]), RS_FONT_PLAIN_11);
+    Result := OCR.RecognizeNumber(Button.Bounds,  TOCRColorRule.Create([$FFFFFF]), RS_FONT_PLAIN_12);
 end;
 
 function TRSGrandExchange.GetItemGuidePrice: Int32;

--- a/osr/grandexchange.simba
+++ b/osr/grandexchange.simba
@@ -10,7 +10,7 @@ Methods to interact with the grand exchange.
 
 type
   ERSGEOverviewButton = (
-    HISTORY,
+    CHANGE_TAB,
     COLLECT
   );
   
@@ -44,6 +44,7 @@ type
   ERSGEInterface = (
     UNKNOWN,
     OVERVIEW,
+    HISTORY,
     OFFER_STATUS,
     OFFER_SETUP
   );
@@ -73,7 +74,7 @@ end;
 
 function TRSGrandExchange.GetOverviewButtons: TRSButtonArray;
 begin
-  Result := Self.FindButtons([[45,18], [81,18]]);
+  Result := Self.FindButtons([[45,18], [55,18], [81,18]]);
 end;
 
 function TRSGrandExchange.GetOverviewButton(Button: ERSGEOverviewButton): TRSButton;
@@ -89,7 +90,7 @@ begin
             Exit(Buttons[I]);
       end;
     else
-      if Length(Buttons) >= Length(ERSGEOverviewButton) - 1 then 
+      if Length(Buttons) >= Length(ERSGEOverviewButton) - 1 then
         Result := Buttons[Button];
   end;
 end;
@@ -183,6 +184,8 @@ begin
 end;
 
 function TRSGrandExchange.GetCurrentInterface: ERSGEInterface;
+var
+  tabText : String;
 begin
   if Self.GetSetupOfferButton(ERSGESetupOfferButton.HISTORY).Visible() then
     Result := ERSGEInterface.OFFER_SETUP
@@ -190,8 +193,14 @@ begin
   if Self.GetOfferStatusButton(ERSGEOfferStatusButton.HISTORY).Visible() then
     Result := ERSGEInterface.OFFER_STATUS
   else
-  if Self.GetOverviewButton(ERSGEOverviewButton.HISTORY).Visible() then
-    Result := ERSGEInterface.OVERVIEW;
+  if Self.GetOverviewButton(ERSGEOverviewButton.CHANGE_TAB).Visible() then
+  begin
+    tabText := OCR.Recognize(Self.GetOverviewButton(ERSGEOverviewButton.CHANGE_TAB).Bounds, TOCRColorRule.Create([2070783, $FFFFFF]), RS_FONT_PLAIN_11);
+    if lowercase(tabText) = 'history' then
+      Result := ERSGEInterface.OVERVIEW
+    else if lowercase(tabText) = 'exchange' then
+      Result := ERSGEInterface.HISTORY;
+  end;
 end;
 
 function TRSGrandExchange.IsOpen: Boolean;

--- a/osr/grandexchange.simba
+++ b/osr/grandexchange.simba
@@ -320,11 +320,14 @@ begin
 end;
 
 function TRSGrandExchange.FindSearch(Item: String; out B: TBox): Boolean;
+var
+  searchGrid : tBoxArray := grid(3,3, 160, 32, point(0,0), point(Chat.X1 + 7, Chat.Y1 + 29));
 begin
   if (Item <> '') then
     Item[1] := UpCase(Item[1]);
-    
-  Result := OCR.LocateText(Chat.Bounds, Item, RS_FONT_PLAIN_12,  TOCRColorRule.Create([$000000]), B) = 1;
+
+  for b in searchGrid do
+    if OCR.RecognizeMulti(b, TOCRColorRule.Create([$000000]), RS_FONT_PLAIN_12).Merge(' ') = Item then Exit(True);
 end;
 
 function TRSGrandExchange.ClickSearch(Item: String): Boolean;


### PR DESCRIPTION
Three small changes:

1. Changed the font for trade value reading from `RS_FONT_PLAIN_11` to `RS_FONT_PLAIN_12`
2. Adding HISTORY as an overview screen option, and changing the HISTORY button to CHANGE_TAB button which will allow swapping between tabs in a future update.
3. Fixed item searching (for buy offers) to work with multi-line results. Previously the text looked for any instance of the full item name in the chat box, but that would fail when text wrapped. I created a grid system to progressively read each search result and merge multiple lines into a single result, which has solved the issue in my testing.