### PR TITLE
GrandExchange Updates

### DIFF
--- a/osr/grandexchange.simba
+++ b/osr/grandexchange.simba
@@ -183,14 +183,24 @@ begin
   end;
 end;
 
+function TRSGrandExchange.GetTitleText() : String;
+var
+  titleBox : tBox;
+begin
+  titleBox := [Self.X1, Self.Y1, Self.X2, Self.Y1+30];
+  result := OCR.Recognize(titleBox, TOCRColorRule.Create([2070783]), RS_FONT_BOLD_12);
+end;
+
 function TRSGrandExchange.GetCurrentInterface: ERSGEInterface;
 var
   tabText : String;
 begin
-  if Self.GetSetupOfferButton(ERSGESetupOfferButton.HISTORY).Visible() then
+  //if Self.GetSetupOfferButton(ERSGESetupOfferButton.HISTORY).Visible() then
+  if (Pos('Set up', self.GetTitleText()) > 0) then
     Result := ERSGEInterface.OFFER_SETUP
   else 
-  if Self.GetOfferStatusButton(ERSGEOfferStatusButton.HISTORY).Visible() then
+  //if Self.GetOfferStatusButton(ERSGEOfferStatusButton.HISTORY).Visible() then
+  if (Pos('status', self.GetTitleText()) > 0) then
     Result := ERSGEInterface.OFFER_STATUS
   else
   if Self.GetOverviewButton(ERSGEOverviewButton.CHANGE_TAB).Visible() then

--- a/osr/grandexchange.simba
+++ b/osr/grandexchange.simba
@@ -461,6 +461,10 @@ begin
  
     Columns := Row.Partition(1, 4);
 
+    // The item icon column (2) is much smaller than 25% and the price information (3) is wider than 25%
+    Columns[3].X1 -= 25;
+    Columns[2].X2 := Columns[3].X1;
+
     Item := [];
     Item.Bounds := Row;
 
@@ -480,7 +484,7 @@ begin
     Item.Quantity := SRL.GetItemAmount(Columns[2]);
     if (Item.Quantity = 0) Then
       Item.Quantity := 1;
-      
+
     Item.TotalPrice := OCR.RecognizeNumber(Columns[3], TOCRColorRule.Create([4176127]), RS_FONT_PLAIN_11);
     Item.PreTax     := StrToInt(ExtractFromStr('0' + OCR.Recognize(Columns[3], TOCRColorRule.Create([10461087]), RS_FONT_PLAIN_11).Before(' - '), Numbers));
     Item.PricePerItem := Item.TotalPrice div Item.Quantity;

--- a/osr/grandexchange.simba
+++ b/osr/grandexchange.simba
@@ -311,6 +311,15 @@ begin
   Result := OCR.Recognize(Chat.Bounds,  TOCRColorRule.Create([8388608]), RS_FONT_BOLD_12).StripR('*');
 end;
 
+function TRSGrandExchange.GetPreviousSearch: String;
+var
+  B : tBox;
+begin
+  // Offset from chat to find the result box
+  B := [chat.x1 + 254, chat.y1 + 28, chat.x2 - 138, chat.y2 - 80];
+  result := OCR.RecognizeMulti(B, TOCRColorRule.Create([$000000]), RS_FONT_PLAIN_12).Merge(' ');
+end;
+
 function TRSGrandExchange.ClearSearch: Boolean;
 begin
   while (Self.GetCurrentSearch() <> '') do
@@ -348,16 +357,25 @@ begin
   
   if Self.OpenSearch() and Self.ClearSearch() then
   begin
-    Keyboard.Send(Item);
-    
-    Result := WaitUntil(Self.FindSearch(Item, B), 500, 2500);
+    if self.GetPreviousSearch = Item then
+    begin
+      B := [chat.x1 + 124, chat.y1 + 28, chat.x2 - 138, chat.y2 - 80];
+
+      result := True;
+    end else
+    begin
+      Keyboard.Send(Item);
+
+      Result := WaitUntil(Self.FindSearch(Item, B), 500, 2500);
+    end;
+
     if Result and Click then
       Mouse.Click(B, MOUSE_LEFT);
   end;
 end;
 
 type
-  ERSGEOfferType = (EMPTY, BUY, SELL);
+  ERSGEOfferType = (EMPTY, BUY, SELL, UNKNOWN);
 
   TRSGEOfferStatus = record
     OfferType: ERSGEOfferType;
@@ -394,6 +412,7 @@ begin
     'Empty': Result.OfferType := ERSGEOfferType.EMPTY;
     'Buy':   Result.OfferType := ERSGEOfferType.BUY; 
     'Sell':  Result.OfferType := ERSGEOfferType.SELL;
+    else     Result.OfferType := ERSGEOfferType.UNKNOWN;
   end;
   
   if (Result.OfferType <> ERSGEOfferType.EMPTY) then
@@ -413,6 +432,7 @@ type
     Quantity: Int32;
     PricePerItem: Int32;
     TotalPrice: Int32;
+    PreTax: Int32;
     Bounds: TBox;
   end;
   TRSGEHistory = array of TRSGEHistoryItem;
@@ -462,6 +482,7 @@ begin
       Item.Quantity := 1;
       
     Item.TotalPrice := OCR.RecognizeNumber(Columns[3], TOCRColorRule.Create([4176127]), RS_FONT_PLAIN_11);
+    Item.PreTax     := StrToInt(ExtractFromStr('0' + OCR.Recognize(Columns[3], TOCRColorRule.Create([10461087]), RS_FONT_PLAIN_11).Before(' - '), Numbers));
     Item.PricePerItem := Item.TotalPrice div Item.Quantity;
 
     Result := Result + Item;

--- a/osr/grandexchange.simba
+++ b/osr/grandexchange.simba
@@ -330,7 +330,7 @@ end;
 
 function TRSGrandExchange.FindSearch(Item: String; out B: TBox): Boolean;
 var
-  searchGrid : tBoxArray := grid(3,3, 160, 32, point(0,0), point(Chat.X1 + 7, Chat.Y1 + 29));
+  searchGrid : tBoxArray := grid(3,3, 162, 32, point(0,0), point(Chat.X1 + 7, Chat.Y1 + 29));
 begin
   if (Item <> '') then
     Item[1] := UpCase(Item[1]);


### PR DESCRIPTION
A few small changes to bring the TRSGrandExchange interface up to snuff:

1. Added the ability to select the "Previous Search Result" as a quick way to select the last searched item - very helpful in repetitive trades.
2. Added functionality to read the pre-tax price of an item from the History tab. Previously the function only read post-tax.
3. Small tweaks to text boxes for reading. Both the History and Search boxes were slightly off, allowing the text to be cut off when reading on max-width items.
4. Changed the interface detection from button detection to title detection. When some offers were filled, it threw off the button count and falsely detected OFFER_SETUP status from the OVERVIEW interface.