### PR TITLE
GE: Removed cash failsafe

### DIFF
--- a/osr/interfaces/core/item_interface.simba
+++ b/osr/interfaces/core/item_interface.simba
@@ -18,8 +18,8 @@ begin
 
   boxes := Self.GetSearchBoxesFunction();
   for i := 0 to High(slots) do
-    if InRange(i, 0, High(boxes)) then
-      Result += boxes[i];
+    if InRange(slots[i], 0, High(boxes)) then
+      Result += boxes[slots[i]];
 end;
 
 function TRSItemInterface.GetSlotBox(slot: Int32): TBox;

--- a/osr/interfaces/mainscreen/grandexchange.simba
+++ b/osr/interfaces/mainscreen/grandexchange.simba
@@ -824,12 +824,6 @@ begin
 
     wait(random(400,800));
 
-    if self.GetItemTotalPrice() > self.readCash() then
-    begin
-      self.DebugLn('TRSGrandExchange.createBuyOffer: Cash is not sufficient to cover this offer');
-      exit(False);
-    end;
-
     if self._clickConfirm() then
       result := waitUntil(self.GetStatus(slotNumber) = ERSGEOfferStatus.ACTIVE, 250, 4000)
     else


### PR DESCRIPTION
Cash can be kept in the bank now, so the failsafe for inventory cash is not required. Scripters must verify there is sufficient coins. Insufficient coins will now cause CreateBuyOffer to fail from not being able to click the confirm button.