### PR TITLE
Bugfix for where System.IndexOf returns 0 for empty array

### DIFF
--- a/utils/stringarrays.simba
+++ b/utils/stringarrays.simba
@@ -75,6 +75,9 @@ end;
 
 function TStringArray.Find(const Value: String): Integer; constref;
 begin
+  if (self.Len() = 0) then
+    Exit(-1);
+    
   Result := System.IndexOf(value, Self);
 end;
 

--- a/utils/stringarrays.simba
+++ b/utils/stringarrays.simba
@@ -75,7 +75,7 @@ end;
 
 function TStringArray.Find(const Value: String): Integer; constref;
 begin
-  if (self.Len() = 0) then
+  if (Length(self) = 0) then
     Exit(-1);
     
   Result := System.IndexOf(value, Self);


### PR DESCRIPTION
```pascal
procedure TSATest();
var
  TSA: TStringArray;
begin
  writeln(TSA.Find('hi'));
end;  
```
returns 0 when it should return -1