### PR TITLE
Update bank.simba: Quantity Mainscreen.IsUpText failed

### DIFF
--- a/osr/interfaces/mainscreen/bank.simba
+++ b/osr/interfaces/mainscreen/bank.simba
@@ -40,6 +40,7 @@ type
     FINDER_OPTION: TStringArray;
     QUANTITY_ALL: Int32;
     QUANTITY_ALL_BUT_ONE: Int32;
+    CachedQuantity: Int32;
   end;
 
   TRSBankItem = record
@@ -1034,13 +1035,17 @@ begin
 
   Mouse.Move(b);
 
-  if (toStr(amount) = MainScreen.GetUpText.After('Withdraw-').Before(' ')) then
+  if (amount = Self.CachedQuantity) or (amount = MainScreen.GetUpText().ExtractNumber(Self.CachedQuantity)) then
   begin
+    Self.CachedQuantity := amount;
     Mouse.Click(MOUSE_LEFT);
     Exit(True);
   end;
 
+  Self.CachedQuantity := 0; //in case we falsely return the next statement true we reset this.
   Result := ChooseOption.Select('Withdraw-X') and Chat.AnswerQuery('Enter amount', ToString(amount), Random(2000, 4000));
+  if Result then
+    Self.CachedQuantity := amount;
 end;
 
 

--- a/osr/interfaces/mainscreen/bank.simba
+++ b/osr/interfaces/mainscreen/bank.simba
@@ -40,7 +40,6 @@ type
     FINDER_OPTION: TStringArray;
     QUANTITY_ALL: Int32;
     QUANTITY_ALL_BUT_ONE: Int32;
-    CachedQuantity: Int32;
   end;
 
   TRSBankItem = record
@@ -1035,17 +1034,13 @@ begin
 
   Mouse.Move(b);
 
-  if (Self.CachedQuantity = amount) or MainScreen.IsUpText('Withdraw-' + ToString(amount)) then
+  if (amount = StrToInt(MainScreen.GetUpText.After('Withdraw-').Before(' '))) then
   begin
-    Self.CachedQuantity := amount;
     Mouse.Click(MOUSE_LEFT);
     Exit(True);
   end;
 
-  Self.CachedQuantity := 0; //in case we falsely return the next statement true we reset this.
   Result := ChooseOption.Select('Withdraw-X') and Chat.AnswerQuery('Enter amount', ToString(amount), Random(2000, 4000));
-  if Result then
-    Self.CachedQuantity := amount;
 end;
 
 

--- a/osr/interfaces/mainscreen/bank.simba
+++ b/osr/interfaces/mainscreen/bank.simba
@@ -1034,7 +1034,7 @@ begin
 
   Mouse.Move(b);
 
-  if (amount = StrToInt(MainScreen.GetUpText.After('Withdraw-').Before(' '))) then
+  if (toStr(amount) = MainScreen.GetUpText.After('Withdraw-').Before(' ')) then
   begin
     Mouse.Click(MOUSE_LEFT);
     Exit(True);


### PR DESCRIPTION
Bug fix for WithdrawHelper quantity: Mainscreen.IsUpText fails to read the difference between Withdraw-2 and Withdraw-20. Replace with Mainscreen.GetUpText with filter for number for a more accurate reading of quantity.