### PR TITLE
Update inventory.simba

### DIFF
--- a/osr/interfaces/gametabs/inventory.simba
+++ b/osr/interfaces/gametabs/inventory.simba
@@ -381,7 +381,7 @@ end;
 
 procedure TRSInventory.Draw(Bitmap: TMufasaBitmap); override;
 begin
-  if not Self.Open() then
+  if not Self.IsOpen() then
     Exit;
 
   inherited();

--- a/osr/interfaces/gametabs/inventory.simba
+++ b/osr/interfaces/gametabs/inventory.simba
@@ -381,7 +381,7 @@ end;
 
 procedure TRSInventory.Draw(Bitmap: TMufasaBitmap); override;
 begin
-  if not Self.IsOpen() then
+  if not Self.Open() then
     Exit;
 
   inherited();
@@ -685,7 +685,7 @@ if Inventory.MouseItem('Bronze arrows') then
 *)
 function TRSInventory.MouseItem(item: TRSItem): Boolean;
 begin
-  if not Self.IsOpen() then
+  if not Self.Open() then
     Exit;
   Result := Self.ItemInterface.MouseItem(item);
 end;
@@ -707,7 +707,7 @@ WriteLn Inventory.ClickItem('Ashes', 'Drop');
 *)
 function TRSInventory.ClickItem(item: TRSItem; option: String = ''): Boolean;
 begin
-  if not Self.IsOpen() then
+  if not Self.Open() then
     Exit;
 
   Result := Self.ItemInterface.InteractItem(item, option);


### PR DESCRIPTION
IsOpen to Open for MouseSlot and MouseClick, returning expected functionality of opening the inventory before trying to click an item.