### PR TITLE
Faster nearest node finding

### DIFF
--- a/utils/geometry/tpointarrays.simba
+++ b/utils/geometry/tpointarrays.simba
@@ -1617,10 +1617,11 @@ begin
 
   for i := 0 to High(Self) do
   begin
-    if (a = -1) and Self[i].Contains(p) then a := i;
-    if (b = -1) and Self[i].Contains(q) then b := i;
+    if (a = -1) and (Self[i].Intersection([p]) <> []) then a := i;
+    if (b = -1) and (Self[i].Intersection([q]) <> []) then b := i;
     if ((a > -1) or (b > -1)) and (a = b) then Exit(True);
   end;
+
 
   Result := a = b;
 end;

--- a/utils/webgraph.simba
+++ b/utils/webgraph.simba
@@ -274,10 +274,10 @@ begin
     Result[i] := Self.Nodes.find(tpa[i]);
 
   for i := 0 to High(Result) do
-    weights[i] := Length(Self.WalkableSpace.AStar(p, Self.Nodes[Result[i]], False));
+    weights[i] := Round(p.DistanceTo(Self.Nodes[Result[I]]));
 
   for i := 0 to high(Result) do
-    if weights[i] = 0 then weights[i] := $FFFFFF;
+    if not Self.WalkableClusters.InSameTPA(p,Self.Nodes[Result[I]]) then weights[i] := $FFFFFF;
 
   Result.SortWeighted(weights, 0, High(Result), True);
   if weights[0] = $FFFFFF then


### PR DESCRIPTION
Hey Tor, I finally took the time to understand forks. I hope I did it properly :p

changes:
First I made a change that makes the finding of nearest nodes faster by using InSameTPA rather than pathfinding. 
That made my particular case go from 20 seconds of pathfinding to 150ms of pathfinding, but I still found that too slow, so I also made a change in how InSameTPA works and I've made it use a native function 'intersect' instead of the 'contains' function, which is not native which made my particular case drop to 13 ms, which I then deemed acceptable :) 

This change should also be made in the finding of doors on the path. I did it with intersects on my original version but you changed it to use a double for loop, which is highly unoptimal. I'll propose a change to speed that function up soon!