### PR TITLE
Angles were specified too tight

### DIFF
--- a/osr/walker.simba
+++ b/osr/walker.simba
@@ -588,7 +588,7 @@ begin
   if Self._DoorHandler.SettingUp then
     if playerpoint.InRange(Self._DoorHandler.Door.Center, 99) and not playerpoint.InRange(walkerPoint, 20) then
     begin
-      Minimap.SetCompassAngleEx(Self._DoorHandler.Door.GetVisibleAngle(Minimap.GetCompassAngle()), 15);
+      Minimap.SetCompassAngleEx(Self._DoorHandler.Door.GetVisibleAngle(Minimap.GetCompassAngle()));
       Self._DoorHandler.SettingUp := False;
     end;
 
@@ -648,7 +648,7 @@ begin
     if Self._DoorHandler.SettingUp then
       if playerpoint.InRange(Self._DoorHandler.Door.Center, 99) and not playerpoint.InRange(walkerPoint, 20) then
       begin
-        Minimap.SetCompassAngleEx(Self._DoorHandler.Door.GetVisibleAngle(Minimap.GetCompassAngle()), 15);
+        Minimap.SetCompassAngleEx(Self._DoorHandler.Door.GetVisibleAngle(Minimap.GetCompassAngle()));
         Self._DoorHandler.SettingUp := False;
       end;
 


### PR DESCRIPTION
Idk why but the setting up when walking had only 15 degrees of possible rotation allowed, making the walker rotate more often than necessary