### PR TITLE
Object rounding errors reduced

### DIFF
--- a/osr/map/mapobject.simba
+++ b/osr/map/mapobject.simba
@@ -535,6 +535,7 @@ function TRSObjectV2.GetCuboidArray(me: TPoint = [0,0]; angle: Single = $FFFF): 
 var
   Locations: TCoordsAngle;
   p: TPoint;
+  vec: Vector3;
   h, diff: Single;
   i: Int32;
 begin
@@ -557,9 +558,10 @@ begin
   for i := 0 to High(Locations.Coordinates) do
   begin
     p := Locations.Coordinates[i] + Self.Offset;
+    p := RSTranslator.Normalize(p);
     diff := -(h-Self.Walker^.Height(p));
-    p := Self.Walker^.PointToMM(me, p, angle);
-    Result += Minimap.GetCuboidMS(p + [Round(0.15*diff), Round(0.11*diff)], Self.Size, [0,0,diff], angle - radians(Locations.Angles[i]));
+    vec := Self.Walker^.PointToMMVec(me, p, angle);
+    Result += Minimap.GetCuboidMS(vec + [Round(0.15*diff), Round(0.11*diff), 0], Self.Size, [0,0,diff], angle - radians(Locations.Angles[i]));
   end;
 end;
 

--- a/osr/mm2ms.simba
+++ b/osr/mm2ms.simba
@@ -355,6 +355,22 @@ begin
             );
 end;
 
+function TRSMinimap.GetTileMS(vec: Vector3; tile: Vector3 = [1, 1, 0]; offset: Vector3 = [0, 0, 0]; angle: Single = $FFFF): TRectangle; overload;
+begin
+  if not Self.IsPointOn(vec.ToPoint()) then
+    Exit;
+
+  //The above prevents running out of memory from fetching tiles too far away.
+  //Everything at the very edge of the minimap is also roughly the same limit of the render distance.
+  //So even though we could fetch tiles further that are visible they would be pitch black because they are not rendered and kind of pointless.
+  //So this just won't go further if the point is not on the minimap and prevents users from accidentally trying to get tiles that are truly too far.
+
+  if (angle = $FFFF) then
+    angle := Self.GetCompassAngle(False);
+
+  Result := Self.VectorToMSRect(vec + offset + [0, 0, tile.Z], tile.X, tile.Y, angle);
+end;
+
 function TRSMinimap.GetTileArrayMS(locArray: TPointArray; tile: Vector3 = [1, 1, 0]; offset: Vector3 = [0, 0, 0]; angle: Single = $FFFF): TRectArray;
 var
   loc: TPoint;
@@ -421,6 +437,18 @@ begin
   Result.Bottom := Self.GetTileMs(loc, [shape.X, shape.Y, 0], offset, angle);
   if shape.Z <> 0 then
     Result.Top := Self.GetTileMS(loc, shape, offset, angle)
+  else
+    Result.Top := Result.Bottom;
+end;
+
+function TRSMinimap.GetCuboidMS(vec: Vector3; shape: Vector3 = [1, 1, 4]; offset: Vector3 = [0, 0, 0]; angle: Single = $FFFF): TCuboidEx; overload;
+begin
+  if (angle = $FFFF) then
+    angle := Self.GetCompassAngle(False);
+
+  Result.Bottom := Self.GetTileMs(vec, [shape.X, shape.Y, 0], offset, angle);
+  if shape.Z <> 0 then
+    Result.Top := Self.GetTileMS(vec, shape, offset, angle)
   else
     Result.Top := Result.Bottom;
 end;

--- a/osr/walker.simba
+++ b/osr/walker.simba
@@ -919,6 +919,8 @@ begin
 
   Mouse.Move([Round((2*rect.Mean().X+3*middleOfDoorside.X)/5), Round((2*rect.Mean().Y+3*middleOfDoorside.Y)/5)]);
 
+  Self._DoorHandler.Skipped := False; //I can't explain why but without this like, it always skips the door
+
   //Check Uptext and walk through
   if Mainscreen.IsUpText(['Open', 'Squeeze']) then
   begin

--- a/osr/walker.simba
+++ b/osr/walker.simba
@@ -134,6 +134,17 @@ begin
   end;
 end;
 
+function TRSWalkerV2.PointToMMVec(playerPoint, p: TPoint; radians: Double): Vector3;
+var
+  MMpoint: TPoint;
+begin
+  with Minimap.Center() do
+  begin
+    MMPoint := p - playerPoint + [X, Y];
+    Result := Vec3(MMPoint.X,MMPoint.Y).RotateXY(radians, X, Y);
+  end;
+end;
+
 function TRSWalkerV2.PointsToMM(playerPoint: TPoint; tpa: TPointArray; radians: Double): TPointArray;
 var
   p: TPoint;


### PR DESCRIPTION
I made 2 overloads to for finding tiles/cuboids using vectors rather than TPoints. Idk if the other versions still serve a lot of purpose, will need to look into it. Might be worth to make this standard and then make the TPoint version an overload and have it convert the TPoint to a Vec3 and then just call the other one. Using vectors here will make a lot of stuff more accurate, including doors because GetTileMS will be so much more accurate :)

Edit: I also added a line that fixed doors always being skipped