### PR TITLE
Fixes to NPCV2 tile detection

### DIFF
--- a/osr/map/map.simba
+++ b/osr/map/map.simba
@@ -704,15 +704,16 @@ Debug(Map.GetTileMS(Map.Position() + [10, 10]));
 function TRSMap.GetTileMS(playerPoint, mapPoint: TPoint; height: Double = 0; offset: Vector2 = [0,0]): TRectangle;
 var
   radians: Double;
+  mapVec: Vector3;
 begin
   with Minimap.Center() do
   begin
     mapPoint   := [X, Y] + (mapPoint - playerPoint);
-    radians := Minimap.GetCompassAngle(False);
-    mapPoint   := mapPoint.Rotate(radians, [X, Y]);
+    radians    := Minimap.GetCompassAngle(False);
+    mapVec     := Vec3(mapPoint.X,mapPoint.Y).RotateXY(radians, X, Y);
   end;
 
-  Result := Minimap.VectorToMSRect(Vec3(mapPoint.x - offset.X, mapPoint.y - offset.Y, height), 1, 1, radians);
+  Result := Minimap.VectorToMSRect(Vec3(mapVec.x - offset.X, mapVec.y - offset.Y, height), 1, 1, radians);
 end;
 
 function TRSMap.GetTileMS(mapPoint: TPoint; height: Double = 0; offset: Vector2 = [0,0]): TRectangle; overload;

--- a/osr/map/maploader.simba
+++ b/osr/map/maploader.simba
@@ -285,10 +285,20 @@ begin
 
   atpa.sortBySize(0, True);
 
+  hi := High(doors);
+  case hi of
+    0..50: divider := 50;
+    51..400: divider := 100;
+    else divider := 200;
+  end;
+
   for i := 0 to high(doors) do
   begin
+    if i mod divider = 0 then
+      Self.DebugLn('Adding doors to graph: '  + ToStr(i) + '/' + ToStr(hi));
     door := doors[i];
-    if not door.IsSeparatingAreas(atpa) then
+
+    if (door.DoorType = ERSDoorType.UNKNOWN) or atpa.InSameTPA(door.Before, door.After) then
     begin
       nonSepDoors += 1;
       Continue;

--- a/osr/map/mapobject.simba
+++ b/osr/map/mapobject.simba
@@ -746,7 +746,7 @@ end;
 
 function TRSNPCV2.GetCuboidArray(me: TPoint = [0,0]; angle: Single = $FFFF): TCuboidExArray; constref; override;
 var
-  dots, tileGrid, mmGrid: TPointArray;
+  dots, mmGrid: TPointArray;
   p, mmPoint: TPoint;
   vec: Vector3;
   h, diff: Single;
@@ -766,8 +766,6 @@ begin
     if dots = [] then
       Exit;
 
-    tileGrid := [];
-
     // get the pixels on the minimap that correspond to tile coordinates on the map
     // maybe there is a smarter way to do this, but for now it works fine
     for x := Minimap.Center().X - 10 * 4 to Minimap.Center().X + 10 * 4 with 4 do
@@ -775,15 +773,9 @@ begin
       begin
         mmPoint := Vec3(x, y).RotateXY(angle, Minimap.Center().X, Minimap.Center.Y).ToPoint;
         mmGrid += mmPoint;
-        tileGrid += RSTranslator.NormalizeNearestTile(Self.Walker^.MMToMap(me, mmPoint));
       end;
 
-
     dots := dots.Offset(2,1); //This brings the dots closest to the tile center in general, closer than the original 2,2 offset
-    for i := 0 to High(dots) do
-      dots[i] := mmGrid.NearestPoint(dots[i]);
-
-
     dots := dots.Sorted(Minimap.Center());
     for i := 0 to High(dots) do
     begin

--- a/osr/map/mapobject.simba
+++ b/osr/map/mapobject.simba
@@ -944,8 +944,8 @@ begin
 
   if atpa <> [] then
   begin
-    //bitmap.DrawATPA(atpa);
-    //bitmap.DrawTPA(atpa[0], $0);
+    bitmap.DrawATPA(atpa);
+    bitmap.DrawTPA(atpa[0], $0);
   end;
 
   bitmap.DrawCuboidArray(cuboids, $00FFFF);

--- a/osr/map/mapobject.simba
+++ b/osr/map/mapobject.simba
@@ -18,6 +18,7 @@ type
     Actions: TStringArray;
 
     Size: Vector3;
+    Tiles: Integer;
     Coordinates: TPointArray;
 
     Finder: TRSObjectFinder;
@@ -724,6 +725,8 @@ begin
 
   Result.Actions := TRSMapObject.GetActions(json.getJSONArray('actions'));
   Result.Size := TRSMapObject.GetSize(json.getJSONArray('size'));
+  Result.Tiles := Ceil(Result.Size.X);
+  Result.Offset := [2,2]*(Result.Tiles - 1);
 
   Result := Result.Merge(json.getJSONArray('coordinates'), json.getJSONArray('colors'));
   Result.Finder.ColorClusters := [];
@@ -746,8 +749,9 @@ end;
 
 function TRSNPCV2.GetCuboidArray(me: TPoint = [0,0]; angle: Single = $FFFF): TCuboidExArray; constref; override;
 var
-  dots, mmGrid: TPointArray;
-  p, mmPoint: TPoint;
+  dots: TPointArray;
+  dotsVec3Arr, mmGridVec3Arr: Vector3Array;
+  p: TPoint;
   vec: Vector3;
   h, diff: Single;
   i, x, y: Int32;
@@ -766,22 +770,28 @@ begin
     if dots = [] then
       Exit;
 
-    // get the pixels on the minimap that correspond to tile coordinates on the map
-    // maybe there is a smarter way to do this, but for now it works fine
     for x := Minimap.Center().X - 10 * 4 to Minimap.Center().X + 10 * 4 with 4 do
       for y := Minimap.Center().Y - 10 * 4 to Minimap.Center().Y + 10 * 4 with 4 do
       begin
-        mmPoint := Vec3(x, y).RotateXY(angle, Minimap.Center().X, Minimap.Center.Y).ToPoint;
-        mmGrid += mmPoint;
+        mmGridVec3Arr += Vec3(x, y).RotateXY(angle, Minimap.Center().X, Minimap.Center.Y);
       end;
 
-    dots := dots.Offset(2,1); //This brings the dots closest to the tile center in general, closer than the original 2,2 offset
+    dotsVec3Arr.FromTPA(dots);
+    dotsVec3Arr := dotsVec3Arr.Offset([1.5,1.5]);
+    dotsVec3Arr := dotsVec3Arr.Offset(Vec3(-2,-2).RotateXY(angle, 0,0)*(Self.Tiles-1));
+
+    for i := 0 to high(dotsVec3Arr) do
+    begin
+      dotsVec3Arr[i] := mmGridVec3Arr.NearestVec(dotsVec3Arr[i]);
+    end;
+
+    dots := dotsVec3Arr.ToTPA();
     dots := dots.Sorted(Minimap.Center());
     for i := 0 to High(dots) do
     begin
-      p := mmGrid.NearestPoint(dots[i]);  // snap minimap dot onto nearest 'tile' point on the minimap
+      p := dots[i];  // snap minimap dot onto nearest 'tile' point on the minimap
       p := Self.Walker^.MMToMap(me, p, angle); // transfer back from minimap grid to map grid
-      p := RSTranslator.NormalizeNearestTile(p)+ Self.Offset; // read comments above NormalizeNearestTile for more info, also standard offset of [2,2] has been removed
+      p := RSTranslator.NormalizeNearestTile(p) + Self.Offset; // read comments above NormalizeNearestTile for more info, also standard offset of [2,2] has been removed
       diff := -(h-Self.Walker^.Height(p)) / 4;
       vec := Self.Walker^.PointToMMVec(me, p, angle);
       Result += Minimap.GetCuboidMS(vec + [Round(0.15*diff), Round(0.11*diff), 0], Self.Size, [0,0,diff], angle);

--- a/osr/map/mapobject.simba
+++ b/osr/map/mapobject.simba
@@ -720,7 +720,7 @@ begin
   Result.ID := json.getInt('id');
   Result.Name := json.getString('name');
   Result.Category := json.getInt('category');
-  Result.Offset := [2,2];
+  Result.Offset := [0,0]; //This is now no longer needs to be [2,2] by default, unless the npc has an actual offset from the center of the tile
 
   Result.Actions := TRSMapObject.GetActions(json.getJSONArray('actions'));
   Result.Size := TRSMapObject.GetSize(json.getJSONArray('size'));
@@ -746,10 +746,11 @@ end;
 
 function TRSNPCV2.GetCuboidArray(me: TPoint = [0,0]; angle: Single = $FFFF): TCuboidExArray; constref; override;
 var
-  dots: TPointArray;
-  p: TPoint;
+  dots, tileGrid, mmGrid: TPointArray;
+  p, mmPoint: TPoint;
+  vec: Vector3;
   h, diff: Single;
-  i: Int32;
+  i, x, y: Int32;
 begin
   if Self.Filter.Walker and (me = [0,0]) then
     me := Self.Walker^.Position();
@@ -765,13 +766,33 @@ begin
     if dots = [] then
       Exit;
 
+    tileGrid := [];
+
+    // get the pixels on the minimap that correspond to tile coordinates on the map
+    // maybe there is a smarter way to do this, but for now it works fine
+    for x := Minimap.Center().X - 10 * 4 to Minimap.Center().X + 10 * 4 with 4 do
+      for y := Minimap.Center().Y - 10 * 4 to Minimap.Center().Y + 10 * 4 with 4 do
+      begin
+        mmPoint := Vec3(x, y).RotateXY(angle, Minimap.Center().X, Minimap.Center.Y).ToPoint;
+        mmGrid += mmPoint;
+        tileGrid += RSTranslator.NormalizeNearestTile(Self.Walker^.MMToMap(me, mmPoint));
+      end;
+
+
+    dots := dots.Offset(2,1); //This brings the dots closest to the tile center in general, closer than the original 2,2 offset
+    for i := 0 to High(dots) do
+      dots[i] := mmGrid.NearestPoint(dots[i]);
+
+
     dots := dots.Sorted(Minimap.Center());
     for i := 0 to High(dots) do
     begin
-      p := Self.Walker^.MMToMap(me, p, angle) + Self.Offset;
+      p := mmGrid.NearestPoint(dots[i]);  // snap minimap dot onto nearest 'tile' point on the minimap
+      p := Self.Walker^.MMToMap(me, p, angle); // transfer back from minimap grid to map grid
+      p := RSTranslator.NormalizeNearestTile(p)+ Self.Offset; // read comments above NormalizeNearestTile for more info, also standard offset of [2,2] has been removed
       diff := -(h-Self.Walker^.Height(p)) / 4;
-
-      Result += Minimap.GetCuboidMS(dots[i] + [Round(0.15*diff), Round(0.11*diff)], Self.Size, [2,2,diff], angle);
+      vec := Self.Walker^.PointToMMVec(me, p, angle);
+      Result += Minimap.GetCuboidMS(vec + [Round(0.15*diff), Round(0.11*diff), 0], Self.Size, [0,0,diff], angle);
     end;
 
     Exit;

--- a/osr/map/mapobject.simba
+++ b/osr/map/mapobject.simba
@@ -18,7 +18,6 @@ type
     Actions: TStringArray;
 
     Size: Vector3;
-    Tiles: Integer;
     Coordinates: TPointArray;
 
     Finder: TRSObjectFinder;
@@ -151,6 +150,7 @@ function TRSMapObject.GetCuboidArray(me: TPoint = [0,0]; angle: Single = $FFFF):
 var
   coordinates: TPointArray;
   p: TPoint;
+  vec: Vector3;
   h, diff: Single;
 begin
   if me = [0,0] then
@@ -167,8 +167,8 @@ begin
   begin
     p := p + Self.Offset;
     diff := -(h-Self.Walker^.Height(p));
-    p := Self.Walker^.PointToMM(me, p, angle);
-    Result += Minimap.GetCuboidMS(p + [Round(0.15*diff), Round(0.11*diff)], Self.Size, [0,0,diff], angle);
+    vec := Self.Walker^.PointToMMVec(me, p, angle);
+    Result += Minimap.GetCuboidMS(vec + [Round(0.15*diff), Round(0.11*diff), 0], Self.Size, [0,0,diff], angle);
   end;
 end;
 
@@ -674,6 +674,7 @@ type
     Level: Int32;
     DotType: ERSMinimapDot;
     DotFilters: TRSDotFilterArray;
+    TilesWide: Integer;
   end;
 
   PRSNPCV2 = ^TRSNPCV2;
@@ -721,12 +722,11 @@ begin
   Result.ID := json.getInt('id');
   Result.Name := json.getString('name');
   Result.Category := json.getInt('category');
-  Result.Offset := [0,0]; //This is now no longer needs to be [2,2] by default, unless the npc has an actual offset from the center of the tile
+  Result.Offset := [0,0]; //We don't need standard offset anymore, now ppl can use this to acually offset an NPC that is offcenter
 
   Result.Actions := TRSMapObject.GetActions(json.getJSONArray('actions'));
   Result.Size := TRSMapObject.GetSize(json.getJSONArray('size'));
-  Result.Tiles := Ceil(Result.Size.X);
-  Result.Offset := [2,2]*(Result.Tiles - 1);
+  Result.TilesWide:= Ceil(Result.Size.X);
 
   Result := Result.Merge(json.getJSONArray('coordinates'), json.getJSONArray('colors'));
   Result.Finder.ColorClusters := [];
@@ -748,13 +748,39 @@ end;
 
 
 function TRSNPCV2.GetCuboidArray(me: TPoint = [0,0]; angle: Single = $FFFF): TCuboidExArray; constref; override;
+  //gets the points on the rotated minimap which correspond the closest to actual tile coordinates
+  function _GetMinimapGrid(angle: Single): Vector3Array;
+  var x, y: Integer;
+  begin
+    for x := Minimap.Center().X - 10 * 4 to Minimap.Center().X + 10 * 4 with 4 do
+      for y := Minimap.Center().Y - 10 * 4 to Minimap.Center().Y + 10 * 4 with 4 do
+      begin
+        Result += Vec3(x, y).RotateXY(angle, Minimap.Center().X, Minimap.Center.Y);
+      end;
+  end;
+
+  //translates the minimap dots to the tile coordinates closest to the topleft tile of the NPC
+  function _DotsToTopLeft(NPC: TRSNPCV2; dots: TPointArray; angle: Single): TPointArray;
+  var
+    dotVecs, mmGrid: Vector3Array;
+    i: Integer;
+  begin
+    dotVecs.FromTPA(dots);
+    dotVecs := dotVecs.Offset([2,2]);
+    dotVecs := dotVecs.Offset(Vec3(-2,-2).RotateXY(angle, 0, 0)*(NPC.TilesWide-1));
+
+    mmGrid := _GetMinimapGrid(angle);
+    for i := 0 to High(dotVecs) do
+      dotVecs[i] := mmGrid.NearestVec(dotVecs[i]);
+
+    Result := dotVecs.ToTPA();
+  end;
 var
   dots: TPointArray;
-  dotsVec3Arr, mmGridVec3Arr: Vector3Array;
   p: TPoint;
   vec: Vector3;
   h, diff: Single;
-  i, x, y: Int32;
+  i: Int32;
 begin
   if Self.Filter.Walker and (me = [0,0]) then
     me := Self.Walker^.Position();
@@ -770,30 +796,16 @@ begin
     if dots = [] then
       Exit;
 
-    for x := Minimap.Center().X - 10 * 4 to Minimap.Center().X + 10 * 4 with 4 do
-      for y := Minimap.Center().Y - 10 * 4 to Minimap.Center().Y + 10 * 4 with 4 do
-      begin
-        mmGridVec3Arr += Vec3(x, y).RotateXY(angle, Minimap.Center().X, Minimap.Center.Y);
-      end;
+    dots := _DotsToTopLeft(Self, dots, angle);
 
-    dotsVec3Arr.FromTPA(dots);
-    dotsVec3Arr := dotsVec3Arr.Offset([1.5,1.5]);
-    dotsVec3Arr := dotsVec3Arr.Offset(Vec3(-2,-2).RotateXY(angle, 0,0)*(Self.Tiles-1));
-
-    for i := 0 to high(dotsVec3Arr) do
-    begin
-      dotsVec3Arr[i] := mmGridVec3Arr.NearestVec(dotsVec3Arr[i]);
-    end;
-
-    dots := dotsVec3Arr.ToTPA();
     dots := dots.Sorted(Minimap.Center());
     for i := 0 to High(dots) do
     begin
-      p := dots[i];  // snap minimap dot onto nearest 'tile' point on the minimap
-      p := Self.Walker^.MMToMap(me, p, angle); // transfer back from minimap grid to map grid
-      p := RSTranslator.NormalizeNearestTile(p) + Self.Offset; // read comments above NormalizeNearestTile for more info, also standard offset of [2,2] has been removed
-      diff := -(h-Self.Walker^.Height(p)) / 4;
-      vec := Self.Walker^.PointToMMVec(me, p, angle);
+      p := Self.Walker^.MMToMap(me, dots[i], angle); // transfer back from minimap grid to map grid
+      p := RSTranslator.NormalizeNearestTile(p) + [2,2]*(Self.TilesWide-1); //Go from topleft corner of npc to center
+      p := p + Self.Offset; //User specified offset
+      diff := -(h-Self.Walker^.Height(p))/4;
+      vec := Self.Walker^.PointToMMVec(me, p, angle); //translate back to MM space, use vectors to avoid rounding errors
       Result += Minimap.GetCuboidMS(vec + [Round(0.15*diff), Round(0.11*diff), 0], Self.Size, [0,0,diff], angle);
     end;
 
@@ -814,11 +826,13 @@ begin
   if dots = [] then
     Exit;
 
+  dots := dots.Offset([2,2]); // offset to center of NPC dot, best we can de without walker
+
   for i := 0 to High(dots) do
   begin
     p := dots[i] + Self.Offset;
-    p := Self.Walker^.PointToMM(me, p, angle);
-    Result += Minimap.GetCuboidMS(p, Self.Size, [0,0,0], angle);
+    vec := Self.Walker^.PointToMMVec(me, p, angle);
+    Result += Minimap.GetCuboidMS(vec, Self.Size, [0,0,0], angle);
   end;
 end;
 
@@ -930,8 +944,8 @@ begin
 
   if atpa <> [] then
   begin
-    bitmap.DrawATPA(atpa);
-    bitmap.DrawTPA(atpa[0], $0);
+    //bitmap.DrawATPA(atpa);
+    //bitmap.DrawTPA(atpa[0], $0);
   end;
 
   bitmap.DrawCuboidArray(cuboids, $00FFFF);

--- a/osr/walker.simba
+++ b/osr/walker.simba
@@ -187,6 +187,8 @@ begin
 end;
 
 function TRSWalkerV2.GetRectMS(playerPoint, mapPoint: TPoint; height: Double = 0; offset: Vector2 = [0,0]; radians: Single = $FFFF): TRectangle;
+var
+  mapVec: Vector3;
 begin
   if radians = $FFFF then
     radians := Minimap.GetCompassAngle(False);
@@ -194,10 +196,10 @@ begin
   with Minimap.Center() do
   begin
     mapPoint   := [X, Y] + (mapPoint - playerPoint);
-    mapPoint   := mapPoint.Rotate(radians, [X, Y]);
+    mapVec     := Vec3(mapPoint.X,mapPoint.Y).RotateXY(radians, X, Y);
   end;
 
-  Result := Minimap.VectorToMSRect(Vec3(mapPoint.x - offset.X, mapPoint.y - offset.Y, height), 1, 1, radians);
+  Result := Minimap.VectorToMSRect(Vec3(mapVec.X - offset.X, mapVec.Y - offset.Y, height), 1, 1, radians);
 end;
 
 function TRSWalkerV2.MMToMap(playerPoint, minimapPoint: TPoint; radians: Single = $FFFF): TPoint;

--- a/utils/geometry/tpointarrays.simba
+++ b/utils/geometry/tpointarrays.simba
@@ -1607,23 +1607,16 @@ begin
     Result[i] := GetTPABounds(Self[i]);
 end;
 
-
 function T2DPointArray.InSameTPA(p, q: TPoint): Boolean;
 var
-  i, a, b: Int32;
+  i, len: Int32;
 begin
-  a := -1;
-  b := -1;
-
   for i := 0 to High(Self) do
   begin
-    if (a = -1) and (Self[i].Intersection([p]) <> []) then a := i;
-    if (b = -1) and (Self[i].Intersection([q]) <> []) then b := i;
-    if ((a > -1) or (b > -1)) and (a = b) then Exit(True);
+    len := Length(Self[i].Intersection([p , q]));
+    if len = 1 then Exit(False);
+    if len = 2 then Exit(True);
   end;
-
-
-  Result := a = b;
 end;
 
 function T2DPointArray.First(): TPointArray; constref;

--- a/utils/geometry/vector.simba
+++ b/utils/geometry/vector.simba
@@ -382,6 +382,22 @@ begin
   Result.z := Result.z / Length(Self);
 end;
 
+function Vector3Array.NearestVec(vec: Vector3 = [0,0,0]): Vector3;
+var
+  i, nearest: Int32;
+  dist: Double;
+begin
+  dist := $FFFFFF;
+  for i:=0 to High(Self) do
+  begin
+    if Self[i].Distance(vec) < dist then
+    begin
+      dist := Self[i].Distance(vec);
+      nearest := i;
+    end;
+  end;
+  Result := Self[nearest];
+end;
 
 
 // ---------------------------------------------------------------------------

--- a/utils/math/translator.simba
+++ b/utils/math/translator.simba
@@ -158,6 +158,14 @@ begin
   Result := [p.X - (p.X mod Self.TileSize) + 1, p.Y - (p.Y mod Self.TileSize) + 1];
 end;
 
+function TRSTranslator.NormalizeNearestTile(p: TPoint): TPoint;
+begin
+  if (p.X mod Self.TileSize) = 3 then
+    Result := [p.X - (p.X mod Self.TileSize) + 4, p.Y - (p.Y mod Self.TileSize) + (Self.TileSize div 2)]
+  else
+    Result := [p.X - (p.X mod Self.TileSize), p.Y - (p.Y mod Self.TileSize) + (Self.TileSize div 2)];
+end;
+
 
 var
   RSTranslator: TRSTranslator;

--- a/utils/math/translator.simba
+++ b/utils/math/translator.simba
@@ -158,6 +158,10 @@ begin
   Result := [p.X - (p.X mod Self.TileSize) + 1, p.Y - (p.Y mod Self.TileSize) + 1];
 end;
 
+
+//This normalizes to the nearest tile rather than the tile the current point is on. So if the coordinate gived would be on the fourth column, it returns the tile to the right of it rather that the tile the coordinate is on
+//This should be used whenever you expect that there can be deviations to any side of the coordinate you want and want to prevent that if you go one pixel to the left, you end up with the tile to the left of the one you want
+
 function TRSTranslator.NormalizeNearestTile(p: TPoint): TPoint;
 begin
   if (p.X mod Self.TileSize) = 3 then

--- a/utils/webgraph.simba
+++ b/utils/webgraph.simba
@@ -90,7 +90,7 @@ begin
   for door in Self do
     case door.DoorType of
       ERSDoorType.NORMAL:
-        if door.isSeparatingAreas(atpa) then
+        if door.SEPARATING then
           bmp.drawCross(door.Center, 3, $FF)
         else
           bmp.drawCross(door.Center, 3, $FFFF00);

--- a/utils/webgraph.simba
+++ b/utils/webgraph.simba
@@ -19,20 +19,6 @@ type
 
   TRSDoorArray = array of TRSDoor;
 
-//check if a door separates two closed off clusters of walkable space
-function TRSDoor.IsSeparatingAreas(atpa: T2dPointArray): Boolean;
-var
-  tpa: TPointArray;
-begin
-  if Self.DoorType = ERSDoorType.UNKNOWN then
-    Exit;
-
-  for tpa in atpa do
-    if tpa.ContainsAll([Self.Center + Self.Direction, Self.Center - Self.Direction]) then
-      Exit;
-
-  Result := True;
-end;
 
 //This is the number of degrees you need to face the compass to face the door directly.
 //It works by selecting the cardinal direction that gives the highest inner product


### PR DESCRIPTION
Detecting NPC's should now be a whole lot smoother. Also people probably need to remove the offsets they had before

Edit: Also works for large NPC's now. Code looks a bit messy with all the Vector3Arrays but it works so that's something :)
All the weird math with offsets being added and subtracted at different stages in the process is all in the name of getting the topleft tile of the npc and then you can calculate it's center by adding the TRSNPCV2.Offset that I enforced from there.

Edit 2: I scrapped a lot of stuff from edit 1 and made the NPC detection a bit more readable. Also Offset is cleared again and can now be used to actually offset npc's that are not centered on the tile. So [0,0] means you well target the center of the NPC now. I also made removed rounding errors in all the GetTileMS-like functions, just like I did before for objects

Edit 3: Kriptic noticed some serious performance issues on big maps, which was due to some code of me that was N^2 scaling and not using native functions, so I made it a bit smarter and optimized InSameTPA as well to improve the speed even further. Now InSameTPA uses like 50% less calls of the intersection function, a lot more optimized therefore.