### PR TITLE
Multiple fixes: WalkClicking to MapObjects fixed and fix to NPC offset when user didnt specify NPC.TilesWide

### DIFF
--- a/osr/map/mapobject.simba
+++ b/osr/map/mapobject.simba
@@ -1153,7 +1153,7 @@ var
   shouldExit: Boolean;
   attempt: Int32;
   atpa: T2DPointArray;
-  tpa: TPointArray;
+  tpa, path: TPointArray;
   angle: Double;
   me, closest: TPoint;
 begin
@@ -1187,7 +1187,9 @@ begin
       Exit(True);
 
     me := Self.Walker^.Position();
-    closest := Self.Walker^.GetClosestPointEx(me, Self.Coordinates);
+    closest := Self.Walker^.GetClosestPointEx(me, Self.Coordinates, path);
+    if Length(path) = 0 then
+      closest := Self.Walker^.WebGraph^.Nodes[Self.Walker^.WebGraph^.FindNearestNode(closest)];
     if not Self.Walker^.InRangeEx(me, closest, 50) then
     begin
       Self.Walker^.WebWalkEx(me, closest, 30, 0.15);
@@ -1296,7 +1298,6 @@ begin
 
   me :=  Self.Walker^.Position();
   p := Self.Walker^.GetClosestPointEx(me, Self.Coordinates, path);
-
   //if the point is not reachable with the webgraph (like a banker behind a booth) then pick nearest node as target
   if Length(path) = 0 then
     p := Self.Walker^.WebGraph^.Nodes[Self.Walker^.WebGraph^.FindNearestNode(p)];
@@ -1308,7 +1309,7 @@ begin
      not Self.Walker^.WebWalk(p, 30, 0.15) then
       Exit;
   end else
-  if not Self.Walker^.WebWalk(p, 30, 0.15) then  // in this case simply making the target visible doesn't suffice to reachh the npc
+  if not Self.Walker^.WebWalk(p, 30, 0.15) then  // in this case simply making the target visible doesn't suffice to reach the npc
       Exit;
 
   Result := Self._WalkHoverHelper(attempts, Self.TrackTarget);

--- a/osr/map/mapobject.simba
+++ b/osr/map/mapobject.simba
@@ -146,7 +146,7 @@ begin
   Result := Minimap.PointsToMS(coordinates, angle);
 end;
 
-function TRSMapObject.GetCuboidArray(me: TPoint = [0,0]; angle: Single = $FFFF): TCuboidExArray; constref;
+function TRSMapObject.GetCuboidArray(me: TPoint = [0,0]; angle: Single = $FFFF): TCuboidExArray;
 var
   coordinates: TPointArray;
   p: TPoint;
@@ -532,7 +532,7 @@ begin
 end;
 
 
-function TRSObjectV2.GetCuboidArray(me: TPoint = [0,0]; angle: Single = $FFFF): TCuboidExArray; constref; override;
+function TRSObjectV2.GetCuboidArray(me: TPoint = [0,0]; angle: Single = $FFFF): TCuboidExArray; override;
 var
   Locations: TCoordsAngle;
   p: TPoint;
@@ -747,7 +747,7 @@ begin
 end;
 
 
-function TRSNPCV2.GetCuboidArray(me: TPoint = [0,0]; angle: Single = $FFFF): TCuboidExArray; constref; override;
+function TRSNPCV2.GetCuboidArray(me: TPoint = [0,0]; angle: Single = $FFFF): TCuboidExArray; override;
   //gets the points on the rotated minimap which correspond the closest to actual tile coordinates
   function _GetMinimapGrid(angle: Single): Vector3Array;
   var x, y: Integer;
@@ -791,6 +791,7 @@ begin
   if Self.Filter.Walker and Self.Filter.Minimap then
   begin
     h := Self.Walker^.Height(me);
+    if Self.TilesWide = 0 then Self.TilesWide := 1;
 
     dots := Minimap.GetFilteredDotArray(Self.DotType, Self.Walker^.FiltersToMM(me, Self.DotFilters, angle));
     if dots = [] then
@@ -1279,7 +1280,8 @@ RSObjects.GEBank.WalkHover();
 *)
 function TRSMapObject.WalkHover(attempts: Int32 = 2): Boolean;
 var
-  p: TPoint;
+  p, me: TPoint;
+  path: TPointArray;
 begin
   if ChooseOption.IsOpen() then
   begin
@@ -1292,9 +1294,21 @@ begin
 
   if Self.Filter.UpText then Self.Walker^.TargetUpText := [Self.Name];
 
-  p := Self.Walker^.GetClosestPoint(Self.Coordinates);
+  me :=  Self.Walker^.Position();
+  p := Self.Walker^.GetClosestPointEx(me, Self.Coordinates, path);
+
+  //if the point is not reachable with the webgraph (like a banker behind a booth) then pick nearest node as target
+  if Length(path) = 0 then
+    p := Self.Walker^.WebGraph^.Nodes[Self.Walker^.WebGraph^.FindNearestNode(p)];
+
+  // check if doors need to be passed to reach target
+  if Self.Walker^.WebGraph^.WalkableClusters.InSameTPA(me, p) then
+  begin //normal logic
   if not Self.Walker^.MakePointVisible(p) and
      not Self.Walker^.WebWalk(p, 30, 0.15) then
+      Exit;
+  end else
+  if not Self.Walker^.WebWalk(p, 30, 0.15) then  // in this case simply making the target visible doesn't suffice to reachh the npc
       Exit;
 
   Result := Self._WalkHoverHelper(attempts, Self.TrackTarget);

--- a/osr/walker.simba
+++ b/osr/walker.simba
@@ -1334,7 +1334,6 @@ end;
 
 function TRSWalkerV2.WebWalk(destination: TPoint; waitUntilDistance: Int32 = 0; pathRandomness: Double = 0; debug: Boolean = False): Boolean;
 begin
-  WriteLn('Begining webwalk');
   Result := Self.WebWalkEx(Self.Position(), destination, waitUntilDistance, pathRandomness, debug);
 end;
 

--- a/osr/walker.simba
+++ b/osr/walker.simba
@@ -1109,10 +1109,10 @@ function TRSWalkerV2.GetClosestPoint(destinations: TPointArray): TPoint;
 ```
 Method used to get the closest Point to the Player out of a TPA.
 *)
-function TRSWalkerV2.GetClosestPointEx(me: TPoint; destinations: TPointArray): TPoint;
+
+function TRSWalkerV2.GetClosestPointEx(me: TPoint; destinations: TPointArray; out path: TPointArray): TPoint; overload;
 var
   shortPaths: T2DPointArray;
-  path: TPointArray;
   shortest, dist: Int32;
   destination: TPoint;
 begin
@@ -1145,7 +1145,16 @@ begin
   if shortPaths = [] then
     Exit(destinations.NearestPoint(me));
 
+  path := shortPaths.RandomValue();
+
   Result := shortPaths.RandomValue().Last();
+end;
+
+function TRSWalkerV2.GetClosestPointEx(me: TPoint; destinations: TPointArray): TPoint; overload;
+var
+  _: TPointArray;
+begin
+  Result := GetClosestPointEx(me, destinations, _);
 end;
 
 function TRSWalkerV2.GetClosestPoint(destinations: TPointArray): TPoint;
@@ -1301,7 +1310,7 @@ begin
 
     Self.DebugLn('Attempting to solve door, attempt ' + ToStr(tries + 1));
 
-    if not Self.WalkDoorway(path, waitUntilDistance, debug) then
+    if not Self.WalkDoorway(path, 0, debug) then
     begin
       Inc(tries);
     end else

--- a/osr/walker.simba
+++ b/osr/walker.simba
@@ -1122,7 +1122,7 @@ begin
   for destination in destinations do
   begin
     try
-      path := Self.WebGraph^.PathBetween(me, destination, 0);
+      path := Self.WebGraph^.PathBetweenEx(me, destination, 0, 1);
     except
       Continue;
     end;
@@ -1334,6 +1334,7 @@ end;
 
 function TRSWalkerV2.WebWalk(destination: TPoint; waitUntilDistance: Int32 = 0; pathRandomness: Double = 0; debug: Boolean = False): Boolean;
 begin
+  WriteLn('Begining webwalk');
   Result := Self.WebWalkEx(Self.Position(), destination, waitUntilDistance, pathRandomness, debug);
 end;
 

--- a/utils/geometry/tpointarrays.simba
+++ b/utils/geometry/tpointarrays.simba
@@ -83,7 +83,7 @@ begin
     SetLength(Self, Length(Arr) + L);
     MemMove(Arr[0],Self[L],Length(Arr)*SizeOf(TPoint));
   end;
-end; 
+end;
 
 function TPointArray.Find(const value: TPoint): Integer; constref;
 begin
@@ -95,38 +95,16 @@ begin
 end;
 
 function TPointArray.Contains(const value: TPoint): Boolean; constref;
+var
+  temp: TPointArray;
 begin
-  Result := Self.Find(value) > -1;
+  temp := [value];
+  Result := Length(temp.Intersection(self)) = 1;
 end;
 
 function TPointArray.ContainsAll(values: TPointArray): Boolean;
-var
-  small, large: ^TPointArray;
-  i, j, found: Int32;
 begin
-  if High(Self) > High(values) then
-  begin
-    small := @values;
-    large := @Self;
-  end
-  else
-  begin
-    small := @Self;
-    large := @values;
-  end;
-
-  for i := 0 to High(large^) do
-    for j := 0 to High(small^) do
-      if small^[j] = large^[i] then
-      begin
-        found += 1;
-        if found = Length(values) then
-          Break(2)
-        else
-          Break;
-      end;
-
-  Result := found = Length(values);
+  Result := Length(Self.Intersection(values)) = Length(values);
 end;
 
 
@@ -192,14 +170,14 @@ begin
     MemMove(self[0], result[0], Length(self)*SizeOf(self[0]));
   if Length(Other) > 0 then
     MemMove(Other[0], result[Length(Self)], Length(Other)*SizeOf(Other[0]));
-end;  
+end;
 
 
 function TPointArray.Equals(Other:TPointArray): Boolean; constref;
 begin
   if (Length(Self) <> Length(Other)) then Exit(False);
   if (Length(Self) = 0) then Exit(True);
-  Result := CompareMem(Self[0], Other[0], length(self)*SizeOf(self[0]));     
+  Result := CompareMem(Self[0], Other[0], length(self)*SizeOf(self[0]));
 end;
 
 
@@ -499,8 +477,8 @@ end;
 ```pascal
 function TPointArray.Edges(): TPointArray; constref;
 ```
-Filters all points out of the given TPointArray which aren't edge-points. 
-Edge-points are points that are on the edge of the TPA, not completely surrounded by other points. 
+Filters all points out of the given TPointArray which aren't edge-points.
+Edge-points are points that are on the edge of the TPA, not completely surrounded by other points.
 Same as Simba's `FindTPAEdges`
 *)
 function TPointArray.Edges(): TPointArray; constref;
@@ -553,7 +531,7 @@ Wraps Simba's `SplitTPA` and `SplitTPAEx`
 function TPointArray.Split(dist: Int32): T2DPointArray; constref;
 begin
   Result := SplitTPA(Self, dist);
-end; 
+end;
 
 function TPointArray.Split(distX,distY: Int32): T2DPointArray; constref; overload;
 begin
@@ -572,12 +550,12 @@ Wraps Simba's `TPAToATPA` and `TPAToATPAEx`
 function TPointArray.ToATPA(WH:Int32): T2DPointArray; constref;
 begin
   Result := TPAToATPA(Self, WH);
-end; 
+end;
 
 function TPointArray.ToATPA(W,H:Int32): T2DPointArray; constref; overload;
 begin
   Result := TPAToATPAEx(Self, W,H);
-end; 
+end;
 
 (*
 ## TPointArray.Offset
@@ -778,7 +756,7 @@ function TPointArray.Connect(): TPointArray; constref;
 var line:TPointArray; i:Int32;
 begin
   if Length(self) = 0 then Exit;
-  
+
   for i:=0 to High(self)-1 do
   begin
     line := TPAFromLine(self[i].x, self[i].y, self[i+1].x, self[i+1].y);
@@ -872,7 +850,7 @@ var
   xl,yl,xh,yh,angle: Double;
   angles, best: Array of Double;
   added: Boolean;
-  
+
   function Modulo(X,Y:Double): Double;
   begin
     Result := X - Floor(X / Y) * Y;
@@ -884,7 +862,7 @@ begin
   TPA := Self.ConvexHull();
   L := High(TPA);
   SetLength(angles, L);
-  
+
   j := 0;
   for i:=0 to (L-1) do
   begin
@@ -894,7 +872,7 @@ begin
     for c:=0 to j do
       if (angles[c] = angle) then
         added := True;
-    
+
     if not(added) then
       angles[Inc(j)-1] := angle;
   end;
@@ -1057,7 +1035,7 @@ begin
   TPA := Copy(Self);
   for i := High(TPA) downto 0 do
     Swap(TPA[i], TPA[Random(0,i)]);
-  
+
   // Add points to circle one by one, and if needed recompute circle
   for i:=0 to High(TPA) do
   begin
@@ -1223,7 +1201,7 @@ var
   Edge: TPointArray := EdgeFromBox(Self.Bounds());
 begin
   Result := (Length(Edge.PointsInRangeOf(Self, 0, 1)) / Length(Edge)) * 100;
-end; 
+end;
 
 (*
 ## TPointArray.InRange

--- a/utils/webgraph.simba
+++ b/utils/webgraph.simba
@@ -83,7 +83,7 @@ begin
 end;
 
 //draw doors on bitmap
-procedure TRSDoorArray.Draw(bmp: TMufasaBitmap; atpa: T2DPointArray);
+procedure TRSDoorArray.Draw(bmp: TMufasaBitmap);
 var
   door: TRSDoor;
 begin

--- a/utils/webgraph.simba
+++ b/utils/webgraph.simba
@@ -83,7 +83,7 @@ begin
 end;
 
 //draw doors on bitmap
-procedure TRSDoorArray.Draw(bmp: TMufasaBitmap);
+procedure TRSDoorArray.Draw(bmp: TMufasaBitmap; atpa: T2DPointArray);
 var
   door: TRSDoor;
 begin
@@ -166,7 +166,7 @@ type
 var
   queue: array of TNode;
   visited: TBoolArray;
-  cIdx, pathIdx, i: Int32;
+  cIdx, pathIdx, i, nodesPast: Int32;
   current, node: TNode;
   p, q: TPoint;
   hyp: Double;
@@ -199,13 +199,16 @@ begin
     Visited[cIdx] := True;
 
     if (cIdx = Goal) then
+    begin
+      WriteLn('Nodes past: ', nodesPast);
       Exit(current.Indices);
-
+    end;
     p := Self.Nodes[cIdx];
     for pathIdx in Self.Paths[cIdx] do
     begin
       if not Visited[pathIdx] then
       begin
+        nodesPast += 1;
         q := Self.Nodes[pathIdx];
         node.Indices := current.Indices + pathIdx;
 
@@ -215,6 +218,7 @@ begin
       end;
     end;
   end;
+  WriteLn('Nodes past: ', nodesPast);
 end;
 
 function TWebGraph.FindNearestNode(P: TPoint): Int32;
@@ -307,17 +311,34 @@ function TWebGraph.PathBetweenEx(p, q: TPoint; rnd: Double = 0; attempts: Int32 
 var
   i, j: Int32;
   nS, nG, nodes: TIntegerArray;
+  changed: Boolean;
+  pCircle, qCircle: TCircle;
+  pArea, qArea: TPointArray;
 begin
-  if not Self.WalkableSpace.Contains(p) then p := RSTranslator.NormalizeDoor(p);
-  if not Self.WalkableSpace.Contains(q) then q := RSTranslator.NormalizeDoor(q);
+  if not Self.WalkableSpace.Contains(p) or not Self.WalkableSpace.Contains(q) then
+  begin
+    p := RSTranslator.NormalizeDoor(p);
+    q := RSTranslator.NormalizeDoor(q);
+    changed := True;
+  end;
 
-  if not Self.WalkableSpace.Contains(p) then p := Self.WalkableSpace.NearestPoint(p);
-  if not Self.WalkableSpace.Contains(q) then q := Self.WalkableSpace.NearestPoint(q);
+  if changed then
+  begin
+    pCircle := [p.x, p.y, 30];
+    qCircle := [p.x, p.y, 30];
+    pArea := pCircle.toTPA(True).Intersection(Self.WalkableSpace);
+    qArea := qCircle.toTPA(True).Intersection(Self.WalkableSpace);
+    if not Self.WalkableSpace.Contains(p) then p := pArea.NearestPoint(p);
+    if not Self.WalkableSpace.Contains(q) then q := qArea.NearestPoint(q);
+  end;
 
   nS := Self.FindNearestNodes(p, attempts);
   nG := Self.FindNearestNodes(q, attempts);
 
   if nS[0] = nG[0] then Exit([p, q]);
+
+  if (Length(nG) = 1) and (Length(Self.Paths[nG[0]]) = 0) then
+    RaiseException('Points ' + p.ToString() + ' and ' + q.ToString() + ' don''t connect!');
 
   attempts -= 1;
 
@@ -325,6 +346,7 @@ begin
     for j := 0 to High(nG) do
     begin
       if nS[i] = nG[j] then Continue;
+
       nodes := Self.FindPath(nS[i],nG[j], rnd);
       if Length(nodes) > 0 then Break(2);
     end;

--- a/utils/webgraph.simba
+++ b/utils/webgraph.simba
@@ -166,7 +166,7 @@ type
 var
   queue: array of TNode;
   visited: TBoolArray;
-  cIdx, pathIdx, i, nodesPast: Int32;
+  cIdx, pathIdx, i: Int32;
   current, node: TNode;
   p, q: TPoint;
   hyp: Double;
@@ -199,16 +199,13 @@ begin
     Visited[cIdx] := True;
 
     if (cIdx = Goal) then
-    begin
-      WriteLn('Nodes past: ', nodesPast);
       Exit(current.Indices);
-    end;
+
     p := Self.Nodes[cIdx];
     for pathIdx in Self.Paths[cIdx] do
     begin
       if not Visited[pathIdx] then
       begin
-        nodesPast += 1;
         q := Self.Nodes[pathIdx];
         node.Indices := current.Indices + pathIdx;
 
@@ -218,7 +215,6 @@ begin
       end;
     end;
   end;
-  WriteLn('Nodes past: ', nodesPast);
 end;
 
 function TWebGraph.FindNearestNode(P: TPoint): Int32;
@@ -346,7 +342,6 @@ begin
     for j := 0 to High(nG) do
     begin
       if nS[i] = nG[j] then Continue;
-
       nodes := Self.FindPath(nS[i],nG[j], rnd);
       if Length(nodes) > 0 then Break(2);
     end;


### PR DESCRIPTION
The fix with walkclicking to object is so that it first walks in to the same walkable TPA before doing trying to click on it. This also entails a slight change to webwalking: whenever you are still walking through a door, do not yet activate the WaitUntilDistance parameter given to the function, or the function will think it successfully walked through a door when it hasn't yet.

Second fix is a small one that sets the default value of NPC.TilesWide to 1 if it wasn't specified by the user. This fixes an issue there a half-tile offset would be added if there was no user specified npc width.