### PR TITLE
Grand Exchange Updates

### DIFF
--- a/osr/interfaces/mainscreen/grandexchange.simba
+++ b/osr/interfaces/mainscreen/grandexchange.simba
@@ -894,10 +894,7 @@ begin
     exit(False);
   end;
 
-  Inventory.ClickSlot(invSlot);
-
-  if ChooseOption.IsOpen(600) then
-    ChooseOption.Select('Offer');
+  Mouse.Click(Inventory.GetSlotBox(InvSlot), MOUSE_LEFT);
 
   if not waitUntil((self.GetItemQuantity > 0), 250, 3000) then
   begin
@@ -908,7 +905,9 @@ begin
     Self.Open();
     WaitUntil(Self.IsOpen, 500, 4000);
 
-    Inventory.ClickSlot(invSlot, "Offer");
+    Mouse.Move(Inventory.GetSlotBox(InvSlot), True);
+    ChooseOption.Select('Offer');
+
     if not waitUntil((self.GetItemQuantity > 0), 250, 3000) then
     begin
       self.DebugLn('TRSGrandExchange.createSellOffer: Offer quantity did not show up, failed to open offer');

--- a/osr/interfaces/mainscreen/grandexchange.simba
+++ b/osr/interfaces/mainscreen/grandexchange.simba
@@ -904,9 +904,9 @@ begin
     self.DebugLn('TRSGrandExchange.createSellOffer: Offer quantity did not show up, retrying');
 
     Self.Close();
-    wait(Random(750,1500));
+    wait(Random(2000,4500));
     Self.Open();
-    wait(Random(750,1500));
+    WaitUntil(Self.IsOpen, 500, 4000);
 
     Inventory.ClickSlot(invSlot, "Offer");
     if not waitUntil((self.GetItemQuantity > 0), 250, 3000) then

--- a/osr/interfaces/mainscreen/grandexchange.simba
+++ b/osr/interfaces/mainscreen/grandexchange.simba
@@ -264,6 +264,15 @@ begin
   Result := Self.ClickCloseButton(PressEscape) and WaitUntil(not Self.IsOpen(), SRL.TruncatedGauss(50, 1500), Random(1500, 2000));
 end;
 
+function TRSGrandExchange.Reboot() : Boolean;
+begin
+  if Self.IsOpen() then
+    if not Self.Close() then Exit(False);
+
+  WaitEx(800, 400);
+  Result := Self.Open();
+end;
+
 function TRSGrandExchange.changeTab(toHistory: Boolean = True) : Boolean;
 begin
   if (toHistory and (self.getCurrentInterface() = ERSGEInterface.HISTORY)) or

--- a/osr/interfaces/mainscreen/grandexchange.simba
+++ b/osr/interfaces/mainscreen/grandexchange.simba
@@ -1057,9 +1057,16 @@ begin
   result := waitUntil(self.GetCurrentInterface() = ERSGEInterface.OVERVIEW, 200, 2000);
 end;
 
-function TRSGrandExchange.AbortOffer(slotNumber : Int32) : Boolean;
+function TRSGrandExchange._AbortFromMain(slotNumber : Int32) : Boolean;
+begin
+  Mouse.Move(self.GetOfferSlots()[slotNumber]);
+  ChooseOption.Select('Abort');
 
-  // Regular TRSButton does not allow CTS2 or circular buttons
+  Result := WaitUntil(self.GetStatus(slotNumber) = ERSGEOfferStatus.ABORTED, 100, 2500);
+end;
+
+function TRSGrandExchange._AbortFromSlot() : Boolean;
+// Regular TRSButton does not allow CTS2 or circular buttons
   // This is customized based on FindButtons but for this specific circle
   function findAbortButton() : tBox;
   var
@@ -1088,7 +1095,31 @@ function TRSGrandExchange.AbortOffer(slotNumber : Int32) : Boolean;
     end;
   end;
 
-var itemCount : Int32;
+var
+  itemCount : Int32;
+begin
+  if (self.GetCurrentInterface() <> ERSGEInterface.OFFER_STATUS) then
+  begin
+    Self.DebugLn('WARNING: Could not abort offer from slot, slot is not open');
+    exit(False);
+  end;
+
+  // Failsafe to last-second check if it's already aborted
+  if SRL.CountColor(143, self.GetOfferStatusButton(ERSGEOfferStatusButton.PROGRESS).Bounds) > 0 then
+  begin
+    self.DebugLn('AbortOffer: Slot is already aborted');
+    exit(true);
+  end;
+
+  itemCount := self.CountCollectionSlots();
+  Mouse.Click(FindAbortButton().Middle().Random(1,4), MOUSE_LEFT);
+  Result := waitUntil(self.GetStatus() = ERSGEOfferStatus.ABORTED, 200, 2000);
+
+  if Result then result := waitUntil((self.CountCollectionSlots() > itemCount), 250, 2000);
+end;
+
+function TRSGrandExchange.AbortOffer(slotNumber : Int32 = -1) : Boolean;
+var
 status: ERSGEOfferStatus;
 begin
   status := self.GetStatus(slotnumber);
@@ -1104,21 +1135,16 @@ begin
     exit(true);
   end;
 
-  if (self.GetCurrentInterface() <> ERSGEInterface.OFFER_STATUS) then
-    if not self.OpenActiveOffer(slotNumber) then exit(False);
-
-  // Failsafe in case the status wasn't read correctly above
-  if SRL.CountColor(143, self.GetOfferStatusButton(ERSGEOfferStatusButton.PROGRESS).Bounds) > 0 then
+  if (slotNumber = -1) and (self.GetCurrentInterface() <> ERSGEInterface.OFFER_STATUS) then
   begin
-    self.DebugLn('AbortOffer: Slot ' + toStr(slotNumber) + ' is already aborted');
-    exit(true);
+    self.DebugLn('AbortOffer: Cannot abort from the mainscreen without providing a slot number');
+    exit(False);
   end;
 
-  itemCount := self.CountCollectionSlots();
-  Mouse.Click(FindAbortButton().Middle().Random(1,4), MOUSE_LEFT);
-  Result := waitUntil(self.GetStatus() = ERSGEOfferStatus.ABORTED, 200, 2000);
-
-  if Result then waitUntil((self.CountCollectionSlots() > itemCount), 250, 2000);
+  if (slotNumber = -1) or (self.GetCurrentInterface() = ERSGEInterface.OFFER_STATUS) then
+    result := self._AbortFromSlot()
+  else
+    result := self._AbortFromMain(slotNumber)
 end;
 
 function TRSGrandExchange.CreateBuyOffer(itemName : String; price : String = '-1'; quantity: Int32 = 1; slotNumber : Int32 = -1; loops : Int32) : Boolean; overload;

--- a/osr/interfaces/mainscreen/grandexchange.simba
+++ b/osr/interfaces/mainscreen/grandexchange.simba
@@ -909,11 +909,7 @@ begin
   begin
     self.DebugLn('TRSGrandExchange.createSellOffer: Offer quantity did not show up, retrying');
 
-    Self.Close();
-    wait(Random(2000,4500));
-    Self.Open();
-    WaitUntil(Self.IsOpen, 500, 4000);
-
+    Self.Reboot();
     Mouse.Move(Inventory.GetSlotBox(InvSlot), True);
     ChooseOption.Select('Offer');
 


### PR DESCRIPTION
New Features:
- Added `TRSGrandExchange.Reboot()` as a way to close/re-open the GE interface. This is a last-ditch lag/stuck button resolution in the `TRSGrandExchange.CreateSellOffer()` function.
- Added `TRSGrandExchange._AbortFromMain()` which will right-click on the slot and select abort from the main screen. This could be called directly but is also handled by calling `GrandExchange.AbortSlot(slotNumber)`. This way, previous functionality is maintained - if the slot is open and the script calls `GrandExchange.AbortSlot()` the abort will be completed from the currently opened slot.

Fixes:
- `TRSGrandExchange.CreateSellOffer()` now uses `Self.Reboot()` for instances where clicking the item in the inventory does not create an offer. This is a standard (but not reliably reproduced) bug in the OSRS GE interface.
- In `TRSGrandExchange.CreateSellOffer()` the default behavior does not use `Inventory.ClickSlot()` anymore, instead it uses `Mouse.Click()` and `ChooseOption.Select()`. This is because the overrides from WaspLib are not compatible with GE OCR and cause issues with reliability.