### PR TITLE
fix: login handler now works as intended

### DIFF
--- a/osr/interfaces/login.simba
+++ b/osr/interfaces/login.simba
@@ -568,7 +568,7 @@ begin
   failsafe := current + Random(5000, 7000);
   Self.DebugLn('Handling lobby screen.');
 
-  while not Self.ClickText('CLICK HERE TO PLAY') do
+  while not Self.ClickText('CLICK HERE TO PLAY') or not RSClient.IsLoggedIn() do
   begin
     current := GetTickCount();
     if (current > timeout) then

--- a/osr/interfaces/login.simba
+++ b/osr/interfaces/login.simba
@@ -568,14 +568,17 @@ begin
   failsafe := current + Random(5000, 7000);
   Self.DebugLn('Handling lobby screen.');
 
-  while not Self.ClickText('CLICK HERE TO PLAY') or not RSClient.IsLoggedIn() do
+  while not Self.ClickText('CLICK HERE TO PLAY') do
   begin
     current := GetTickCount();
-    if current > timeout then
+    if (current > timeout) then
     begin
       Self.DebugLn('Lobby screen timed out.');
       Exit;
     end;
+
+    if RSClient.IsLoggedIn() then
+      Exit(True);
 
     if current > failsafe then
       Mouse.Move(Box(Mouse.Position(), 10, 10), True);


### PR DESCRIPTION
I noticed that the login handler always goes until its timeout of 15 seconds so it doesn't properly detect when it entered the game. I found that the logic was faulty. The old system had two things in the while loop. The first `not Self.ClickText('CLICK HERE TO PLAY')` is False right until it clicks the button, then it becomes true, but since the while loop then already has a true statement, it will not even check the second one which is 'not RSClient.IsLoggedIn()'. So basically it never check if you are logged in and also doesn't exit when you have. This fix simply adds a check inside the loop and exits True if it is logged in