### PR TITLE
fix: allows TRSBanks to be setup from custom sets of NPCs and Objects

### DIFF
--- a/osr/map/mapobjectarray.simba
+++ b/osr/map/mapobjectarray.simba
@@ -534,7 +534,7 @@ type
     NPCsCache: TRSNPCV2Array;
   end;
 
-procedure TRSBanks._SetupMapObjects();
+procedure TRSBanks._SetupMapObjects(Objects: TRSObjectJSONParser = Objects; NPCs: TRSNPCJSONParser = NPCs);
 var
   i: Int32;
 begin


### PR DESCRIPTION
Will use global `NPCs` and `Objects`  by default, but now a user can also setup their own custom sets of banks, regardless of the state of the global variables