### PR TITLE
fix: walker no longer selects points to walk to outside the minimap

### DIFF
--- a/osr/walker.simba
+++ b/osr/walker.simba
@@ -705,6 +705,9 @@ begin
 
   if MainScreen.IsVisible(b.Middle) then
     Result := CountColor($0, b.Expand(4, MainScreen.Bounds)) = 0; //Client doesn't always render everything when zoomed out
+
+  if Result then
+    Exit(Minimap.IsPointOn(mmPoint, -1));
 end;
 
 

--- a/utils/webgraphv2.simba
+++ b/utils/webgraphv2.simba
@@ -131,7 +131,9 @@ procedure TWebGraphV2.BlockInside(area: TBox);
 var
   i, c: Int32;
 begin
+  c := Length(blocking);
   SetLength(blocking, Length(Self.Nodes));
+
 
   for i := 0 to High(Self.Nodes) do
     if area.Contains(Self.Nodes[i]) then
@@ -147,6 +149,7 @@ procedure TWebGraphV2.BlockOutside(Area: TBox);
 var
   i, c: Int32;
 begin
+  c := Length(blocking);
   SetLength(Blocking, Length(Self.Nodes));
 
   for i := 0 to High(Self.Nodes) do


### PR DESCRIPTION
Small bug fix that makes sure that points selected by the walker to walk to are also on the minimap. This is usually the case either way, but not if you are on a hill, then points outside the minimap will appear on screen and screenwalking will select them, which then later causes issues (more specifically,`TRSWalkerV2.WalkStepHelper` will check if the point in is on the zoom rectangle, which it will not be according to the minimap). This is essentially a desync between heightmap and the old walker system with the 'ZoomRectangle'. Heightmaps allows points outside the traditional ZoomRectangle to be visible.