### PR TITLE
fix(bank): increase FilterDimensions min height to reject stray pixels

### DIFF
--- a/osr/interfaces/mainscreen/bank.simba
+++ b/osr/interfaces/mainscreen/bank.simba
@@ -201,7 +201,7 @@ begin
 
   SRL.FindColors(tpa, CTS0($232B2E, 5), Self.BottomBar);
   atpa := tpa.Cluster(1);
-  atpa.FilterDimensions(0, 0, 2, 32);
+  atpa.FilterDimensions(0, 20, 2, 32);
   if Length(atpa) <> 3 then
     Exit;
 
@@ -218,7 +218,7 @@ begin
     Exit;
   SRL.FindColors(tpa, CTS0($232B2E, 5), Self.BottomBar);
   atpa := tpa.Cluster(1);
-  atpa.FilterDimensions(0, 0, 2, 32);
+  atpa.FilterDimensions(0, 20, 2, 32);
   if Length(atpa) <> 3 then
     Exit;
 
@@ -235,7 +235,7 @@ begin
     Exit;
   SRL.FindColors(tpa, CTS0($232B2E, 5), Self.BottomBar);
   atpa := tpa.Cluster(1);
-  atpa.FilterDimensions(0, 0, 2, 32);
+  atpa.FilterDimensions(0, 20, 2, 32);
   if Length(atpa) <> 3 then
     Exit;
 
@@ -252,7 +252,7 @@ begin
     Exit;
   SRL.FindColors(tpa, CTS0($232B2E, 5), Self.BottomBar);
   atpa := tpa.Cluster(1);
-  atpa.FilterDimensions(0, 0, 2, 32);
+  atpa.FilterDimensions(0, 20, 2, 32);
   if Length(atpa) <> 3 then
     Exit;
 


### PR DESCRIPTION
Stray pixels on bank buttons (e.g. after DepositAll) can match the separator color CTS0($232B2E, 5) and pass FilterDimensions(0, 0, 2, 32) as 1x1 clusters. This causes all four Get*Section() methods to fail since they require exactly 3 separators.

Raising the minimum height from 0 to 20 filters out stray pixels while keeping the real 1x29 separator lines.

BEFORE:
<img width="1734" height="136" alt="image" src="https://github.com/user-attachments/assets/5635326e-72f7-4aa4-8261-a2a77061517e" />

AFTER:
<img width="1736" height="134" alt="image" src="https://github.com/user-attachments/assets/4871d7a4-6bce-4c53-a306-f99ed341bf1c" />
