### PR TITLE
fix(magic): lower ARCEUUS_COLOR detection threshold from 81 to 60

### DIFF
--- a/osr/interfaces/gametabs/magic.simba
+++ b/osr/interfaces/gametabs/magic.simba
@@ -181,7 +181,7 @@ var
   box: TBox;
 begin
   box := Gametabs.Boxes[ERSGameTab.MAGIC];
-  if SRL.CountColor(ARCEUUS_COLOR, box) >= 81 then Exit(ERSSpellBook.ARCEUUS);
+  if SRL.CountColor(ARCEUUS_COLOR, box) >= 60 then Exit(ERSSpellBook.ARCEUUS);
   if SRL.CountColor(ANCIENT_COLOR, box) >= 85 then Exit(ERSSpellBook.ANCIENT);
   if SRL.CountColor(LUNAR_COLOR,   box) >= 85 then Exit(ERSSpellBook.LUNAR);
 end;


### PR DESCRIPTION
### Summary
The ARCEUUS_COLOR detection threshold of 81 is too high, causing the Arceuus spellbook to be misidentified as Standard.                                                                                                          
                                                                                                                                                                                                                                     Testing shows the Arceuus spellbook only produces a color count of 71, which falls below the current threshold of 81. All other spellbooks correctly return 0 for ARCEUUS_COLOR, so lowering the threshold to 60 is safe.

### Test Results
| Spellbook | Arceuus Count | Ancient Count | Lunar Count |
 |-----------|---------------|---------------|-------------|
 | STANDARD  | 0             | 0             | 0           |
 | LUNAR     | 29            | 0             | 138         |
 | ANCIENT   | 0             | 111           | 0           |                                       
 | ARCEUUS   | **71** ❌        | 0             | 0           |
                                                                                                                                                                                                                                     
With the threshold at 81, the Arceuus spellbook (count 71) fails detection and falls through to Standard.
Lowering the threshold to 60 fixes this while maintaining a safe margin above the next highest false-positive (29 from Lunar).                                                                                                                                                                                                                                 