### PR TITLE
Fixing Weird Bug With Bank.DepositAll();

### DIFF
--- a/osr/interfaces/mainscreen/bank.simba
+++ b/osr/interfaces/mainscreen/bank.simba
@@ -1543,10 +1543,12 @@ begin
 
   btn := Self.GetButton(ERSBankDepositButton.INVENTORY);
   if btn = Default(TRSButton) then
+  begin
+    if not WaitUntil(Self.GetButton(ERSBankDepositButton.INVENTORY).Visible , 10 , 5000) then
     Self.Fatal('This script needs the "Deposit Inventory" button visible!');
-
+  end;
   Result := (Inventory.Count() = 0) or btn.Click();
-end;
+end; 
 
 (*
 ## Bank.DepositEquipment


### PR DESCRIPTION
Added another check to prevent a single bug from triggering the self.Fatal condition being met when weird double clicks happen on the ``Bank.DepositAll()`` function.